### PR TITLE
Document how to use grid certificates for SSL/token auth

### DIFF
--- a/config/01-ce-auth.conf
+++ b/config/01-ce-auth.conf
@@ -7,9 +7,14 @@
 #
 ###############################################################################
 
-# Uncomment the following line if your host certificate was issued by an
+# Uncomment the following lines if your host certificate was issued by an
 # IGTF-accredited CA, such as the InCommon IGTF CA or DigiCert Grid CA-1:
 # https://dl.igtf.net/distribution/igtf/current/accredited/accredited.in
 # If you are using a Let's Encrypt certificate, leave this line commented.
 #
-# CE.USE_GRID_CERTS = True
+# AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem
+# AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/hostkey.pem
+# AUTH_SSL_SERVER_CADIR = /etc/grid-security/certificates
+# AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
+# AUTH_SSL_SERVER_CAFILE =
+# AUTH_SSL_CLIENT_CAFILE =

--- a/config/01-common-auth-defaults.conf
+++ b/config/01-common-auth-defaults.conf
@@ -30,14 +30,5 @@ SEC_CLIENT_ENCRYPTION = OPTIONAL
 GSI_DAEMON_TRUSTED_CA_DIR=/etc/grid-security/certificates
 CERTIFICATE_MAPFILE=/etc/condor-ce/condor_mapfile
 
-# SSL settings
-if $(CE.USE_GRID_CERTS)
-  AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem
-  AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/hostkey.pem
-  AUTH_SSL_SERVER_CADIR = /etc/grid-security/certificates
-  AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
-  AUTH_SSL_SERVER_CAFILE =
-  AUTH_SSL_CLIENT_CAFILE =
-else
-  AUTH_SSL_SERVER_CAFILE = /etc/pki/tls/certs/ca-bundle.crt
-endif
+# SSL settings, appropriate for non-grid hosts
+AUTH_SSL_SERVER_CAFILE = /etc/pki/tls/certs/ca-bundle.crt

--- a/docs/installation/htcondor-ce.md
+++ b/docs/installation/htcondor-ce.md
@@ -159,6 +159,22 @@ as the following HTCondor-CE configuration:
 
             globus_mapping /usr/lib64/libgsi_pep_callout.so argus_pep_callout
 
+#### (Optional) Use grid certificates for SSL authentication ####
+
+By default, HTCondor-CE uses system certificates for authenticating SSL connections and expects a host certificate and
+key in `/etc/grid-security/condor/hostcert.pem` and `/etc/grid-security/condor/hostkey.pem`, respectively.
+If you or your clients are using [IGTF-accredited certificates](https://dl.igtf.net/distribution/igtf/current/accredited/accredited.in),
+set the following configuration in `/etc/condor-ce/config.d/01-ce-auth.conf`:
+
+```
+AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem
+AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/hostkey.pem
+AUTH_SSL_SERVER_CADIR = /etc/grid-security/certificates
+AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
+AUTH_SSL_SERVER_CAFILE =
+AUTH_SSL_CLIENT_CAFILE =
+```
+
 ### Configuring the batch system ###
 
 Before HTCondor-CE can submit jobs to your local batch system, it has to be configured to do so.


### PR DESCRIPTION
Can't use 'if $(CE.USE_GRID_CERTS)' since the if statement is
evaluated at parse time and the admin configuration is parsed after
the provided default configs.

Looking at this config again, though, I think maybe we should set the following regardless:

```
AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem
AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/hostkey.pem
```

Because I'm not sure I see much benefit in the change in behavior that the default values would incur:

```
AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/condor/hostcert.pem
AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/condor/hostkey.pem
```