### PR TITLE
Remove unnecessary documentation references to 'users.htcondor.org'

### DIFF
--- a/config/condor_mapfile
+++ b/config/condor_mapfile
@@ -10,17 +10,17 @@
 # with '\/') with the distinguished name of the incoming user certificate and
 # the unix account under which the job should run, respectively:
 #
-# GSI "^<DISTINGUISHED NAME>$" <USERNAME>@users.htcondor.org
+# GSI "^<DISTINGUISHED NAME>$" <USERNAME>
 
 # VOMS attributes can also be used for mapping:
 #
-# GSI "<DISTINGUISHED NAME>,<VOMS FQAN 1>,<VOMS FQAN 2>,...,<VOMSFQAN N>" <USERNAME>@users.htcondor.org
+# GSI "<DISTINGUISHED NAME>,<VOMS FQAN 1>,<VOMS FQAN 2>,...,<VOMSFQAN N>" <USERNAME>
 
 # You can use regular expressions for mapping certificate and VOMS attribute
 # credentials.  For example, to map any GLOW certificate with the 'htpc' role to
 # the 'glow' user, add a line that looks like the following:
 #
-# GSI ".*,\/GLOW\/Role=htpc.*" glow@users.htcondor.org
+# GSI ".*,\/GLOW\/Role=htpc.*" glow
 #
 # The special token GSS_ASSIST_GRIDMAP indicates one should use the Globus Toolkit
 # callout mechanism (which may involve plugins such as LCMAPS or Argus).

--- a/docs/installation/htcondor-ce.md
+++ b/docs/installation/htcondor-ce.md
@@ -110,7 +110,7 @@ To configure authorization for users submitting jobs with an X.509 proxy certifi
 of the following format:
 
 ```
-GSI "^<DISTINGUISHED NAME>$" <USERNAME>@users.htcondor.org
+GSI "^<DISTINGUISHED NAME>$" <USERNAME>
 ```
 
 Replacing `<DISTINGUISHED NAME`> (escaping any '/' with '\/') and `<USERNAME`> with the distinguished name of the
@@ -119,7 +119,7 @@ incoming certificate and the unix account under which the job should run, respec
 VOMS attributes of incoming X.509 proxy certificates can also be used for mapping:
 
 ```
-GSI "<DISTINGUISHED NAME>,<VOMS FQAN 1>,<VOMS FQAN 2>,...,<VOMSFQAN N>" <USERNAME>@users.htcondor.org
+GSI "<DISTINGUISHED NAME>,<VOMS FQAN 1>,<VOMS FQAN 2>,...,<VOMSFQAN N>" <USERNAME>
 ```
 
 Replacing `<DISTINGUISHED NAME`> (escaping any '/' with '\/'), `<VOMSFQAN`> fields, and `<USERNAME`> with the
@@ -130,7 +130,7 @@ Additionally, you can use regular expressions for mapping certificate and VOMS a
 For example, to map any certificate from the `GLOW` VO with the `htpc` role to the `glow` user, add the following line:
 
 ```
-GSI ".*,\/GLOW\/Role=htpc.*" glow@users.htcondor.org
+GSI ".*,\/GLOW\/Role=htpc.*" glow
 ```
 
 !!! warning


### PR DESCRIPTION
Mapped HTCondor principles without an '@' suffix automatically have
'@users.htcondor.org' appended since it's the default
UID_DOMAIN. Exposing this to users has lead to confusion where they
replace 'htcondor.org' with their own domain, resulting in failure to
submit jobs.