### PR TITLE
Do not require authN for queue reads (SOFTWARE-3860)

### DIFF
--- a/config/01-common-auth-defaults.conf
+++ b/config/01-common-auth-defaults.conf
@@ -30,6 +30,12 @@ SEC_CLIENT_ENCRYPTION = OPTIONAL
 GSI_DAEMON_TRUSTED_CA_DIR=/etc/grid-security/certificates
 CERTIFICATE_MAPFILE=/etc/condor-ce/condor_mapfile
 
+# By default, condor_q attempts to authN a user to only show them their jobs
+# Since read access is optional, this can cause unexpected authN failures
+# N.B. authN negotation here is ultimately decided by the client so this
+# configuration only applies to usage of 'condor_ce_q'
+TOOL.CONDOR_Q_ONLY_MY_JOBS = false
+
 # SSL settings
 if $(CE.USE_GRID_CERTS)
   AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem

--- a/config/01-common-auth-defaults.conf
+++ b/config/01-common-auth-defaults.conf
@@ -30,6 +30,12 @@ SEC_CLIENT_ENCRYPTION = OPTIONAL
 GSI_DAEMON_TRUSTED_CA_DIR=/etc/grid-security/certificates
 CERTIFICATE_MAPFILE=/etc/condor-ce/condor_mapfile
 
+# By default, condor_q attempts to authN a user to only show them their jobs
+# Since read access is optional, this can cause unexpected authN failures
+# N.B. authN negotation here is ultimately decided by the client so this
+# configuration only applies to usage of 'condor_ce_q'
+CONDOR_Q_ONLY_MY_JOBS = false
+
 # SSL settings
 if $(CE.USE_GRID_CERTS)
   AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem

--- a/config/01-common-auth-defaults.conf
+++ b/config/01-common-auth-defaults.conf
@@ -30,12 +30,6 @@ SEC_CLIENT_ENCRYPTION = OPTIONAL
 GSI_DAEMON_TRUSTED_CA_DIR=/etc/grid-security/certificates
 CERTIFICATE_MAPFILE=/etc/condor-ce/condor_mapfile
 
-# By default, condor_q attempts to authN a user to only show them their jobs
-# Since read access is optional, this can cause unexpected authN failures
-# N.B. authN negotation here is ultimately decided by the client so this
-# configuration only applies to usage of 'condor_ce_q'
-CONDOR_Q_ONLY_MY_JOBS = false
-
 # SSL settings
 if $(CE.USE_GRID_CERTS)
   AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem

--- a/src/condor_ce_client_env_bootstrap
+++ b/src/condor_ce_client_env_bootstrap
@@ -4,6 +4,11 @@
 # Condor and HTCondor CE(SOFTWARE-1583)
 export _condor_CLASSAD_USER_LIBS=
 
+# By default, condor_q attempts to authN a user to only show them their jobs
+# Since read access is optional, this can cause unexpected authN failures
+# (SOFTWARE-3860)
+export _condor_CONDOR_Q_ONLY_MY_JOBS=False
+
 # Instead of changing the default in 01-common-auth.conf, we set client auth methods
 # with an env variable. This way, only condor_ce_* tools are affected.
 if [ "$_condor_SEC_CLIENT_AUTHENTICATION_METHODS" = "" ]; then

--- a/src/condor_ce_client_env_bootstrap
+++ b/src/condor_ce_client_env_bootstrap
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# Added to prevent segfaults in client tools with mismatched ClassAd versions between
-# Condor and HTCondor CE(SOFTWARE-1583)
-export _condor_CLASSAD_USER_LIBS=
-
 # By default, condor_q attempts to authN a user to only show them their jobs
 # Since read access is optional, this can cause unexpected authN failures
 # (SOFTWARE-3860)

--- a/src/condor_ce_client_env_bootstrap
+++ b/src/condor_ce_client_env_bootstrap
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-# By default, condor_q attempts to authN a user to only show them their jobs
-# Since read access is optional, this can cause unexpected authN failures
-# (SOFTWARE-3860)
-export _condor_CONDOR_Q_ONLY_MY_JOBS=False
-
 # Instead of changing the default in 01-common-auth.conf, we set client auth methods
 # with an env variable. This way, only condor_ce_* tools are affected.
 if [ "$_condor_SEC_CLIENT_AUTHENTICATION_METHODS" = "" ]; then


### PR DESCRIPTION
This partially reverts commit 90cc27102aa1a37e3c7e1dfe92297a975bc158a4.

We had to re-enable optional encryption/integrity because of an issue
where HTCondor currently returns the IP instead of the alias:

53527005740d9c4434dabef39a27de1fd1b35ba4