### PR TITLE
No reason to try non-FS methods first for client tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ install(PROGRAMS
   src/verify_ce_config.py
   src/condor_ce_startup_internal
   src/condor_ce_env_bootstrap
-  src/condor_ce_client_env_bootstrap
   src/condor_ce_router_defaults
   src/local-wrapper
   src/condor_ce_jobmetrics

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -388,7 +388,6 @@ install -m 0755 -d -p $RPM_BUILD_ROOT/%{_sysconfdir}/logrotate.d
 %config(noreplace) %{_sysconfdir}/condor-ce/condor_mapfile
 
 %{_datadir}/condor-ce/condor_ce_env_bootstrap
-%{_datadir}/condor-ce/condor_ce_client_env_bootstrap
 %{_datadir}/condor-ce/condor_ce_startup
 %{_datadir}/condor-ce/condor_ce_startup_internal
 %{_datadir}/condor-ce/verify_ce_config.py*

--- a/src/condor_ce_client_env_bootstrap
+++ b/src/condor_ce_client_env_bootstrap
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Instead of changing the default in 01-common-auth.conf, we set client auth methods
-# with an env variable. This way, only condor_ce_* tools are affected.
-if [ "$_condor_SEC_CLIENT_AUTHENTICATION_METHODS" = "" ]; then
-    export _condor_SEC_CLIENT_AUTHENTICATION_METHODS=SCITOKENS,GSI,FS
-fi

--- a/src/condor_ce_config_val
+++ b/src/condor_ce_config_val
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_config_val "$@"

--- a/src/condor_ce_history
+++ b/src/condor_ce_history
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_history "$@"

--- a/src/condor_ce_hold
+++ b/src/condor_ce_hold
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_hold "$@"

--- a/src/condor_ce_job_router_info
+++ b/src/condor_ce_job_router_info
@@ -7,7 +7,6 @@ missing_tool()
 }
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 CONDOR_BIN_DIR=$(/usr/bin/dirname $(/usr/bin/which condor_version 2> /dev/null ) 2> /dev/null ) 
 if [ -z "$CONDOR_BIN_DIR" ]; then

--- a/src/condor_ce_off
+++ b/src/condor_ce_off
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_off "$@"

--- a/src/condor_ce_on
+++ b/src/condor_ce_on
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_on "$@"

--- a/src/condor_ce_ping
+++ b/src/condor_ce_ping
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 
 exec condor_ping "$@"

--- a/src/condor_ce_q
+++ b/src/condor_ce_q
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_q "$@"

--- a/src/condor_ce_qedit
+++ b/src/condor_ce_qedit
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_qedit "$@"

--- a/src/condor_ce_reconfig
+++ b/src/condor_ce_reconfig
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_reconfig "$@"

--- a/src/condor_ce_release
+++ b/src/condor_ce_release
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_release "$@"

--- a/src/condor_ce_reschedule
+++ b/src/condor_ce_reschedule
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_reschedule "$@"

--- a/src/condor_ce_restart
+++ b/src/condor_ce_restart
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_restart "$@"

--- a/src/condor_ce_rm
+++ b/src/condor_ce_rm
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_rm "$@"

--- a/src/condor_ce_router_q
+++ b/src/condor_ce_router_q
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_router_q -S "$@"

--- a/src/condor_ce_status
+++ b/src/condor_ce_status
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_status "$@"

--- a/src/condor_ce_store_cred
+++ b/src/condor_ce_store_cred
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_store_cred "$@"

--- a/src/condor_ce_submit
+++ b/src/condor_ce_submit
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_submit "$@"

--- a/src/condor_ce_version
+++ b/src/condor_ce_version
@@ -1,6 +1,5 @@
 #!/bin/sh
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
-. /usr/share/condor-ce/condor_ce_client_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 exec condor_version "$@"


### PR DESCRIPTION
I thought about setting `TOOL.SEC_CLIENT_AUTHENTICATION_METHODS = SCITOKENS,GSI,PASSWORD` but we don't really even need to do that. All the `condor_ce_*` tools for which we have wrappers are really only useful when run locally on the CE, so `FS` should be the preferred auth method.

The only reason I could see someone wanting `SCITOKENS` or `GSI` would be to test their `condor_mapfile` mappings and they could just as easily do that 1) remotely or 2) by setting `_condor_SEC_CLIENT_AUTHENTICATION_METHODS=SCITOKENS,GSI`.