### PR TITLE
Check RemoteWallClockTime is defined, to stop selecting irrelevant data

### DIFF
--- a/contrib/apelscripts/condor_batch.sh
+++ b/contrib/apelscripts/condor_batch.sh
@@ -23,7 +23,7 @@ OUTPUT_FILE="$OUTPUT_DIR/batch-$(date -u --date='yesterday' +%Y%m%d )-$(hostname
 [[ -d $OUTPUT_DIR && -w $OUTPUT_DIR ]] || fail "Cannot write to $OUTPUT_DIR"
 
 # Build the filter for the history command
-CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallclockTime =!= 0"
+CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && !isUndefined(RemoteWallClockTime) && RemoteWallClockTime =!= 0.0 "
 
 HISTORY_EXTRA_ARGS=(-format "\n" EMPTY)
 safe_config_val SCALING_ATTR APEL_SCALING_ATTR

--- a/contrib/apelscripts/condor_batch.sh
+++ b/contrib/apelscripts/condor_batch.sh
@@ -23,7 +23,7 @@ OUTPUT_FILE="$OUTPUT_DIR/batch-$(date -u --date='yesterday' +%Y%m%d )-$(hostname
 [[ -d $OUTPUT_DIR && -w $OUTPUT_DIR ]] || fail "Cannot write to $OUTPUT_DIR"
 
 # Build the filter for the history command
-CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && !isUndefined(RemoteWallClockTime) && RemoteWallClockTime =!= 0.0 "
+CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallClockTime != 0 "
 
 HISTORY_EXTRA_ARGS=(-format "\n" EMPTY)
 safe_config_val SCALING_ATTR APEL_SCALING_ATTR

--- a/contrib/apelscripts/condor_blah.sh
+++ b/contrib/apelscripts/condor_blah.sh
@@ -27,7 +27,7 @@ if [ ! -d $OUTPUT_DIR ] || [ ! -w $OUTPUT_DIR ]; then
 fi
 
 # Build the filter for the history command
-CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallclockTime =!= 0"
+CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && !isUndefined(RemoteWallClockTime) && RemoteWallClockTime =!= 0.0 "
 
 safe_config_val CE_HOST APEL_CE_HOST
 safe_config_val BATCH_HOST APEL_BATCH_HOST

--- a/contrib/apelscripts/condor_blah.sh
+++ b/contrib/apelscripts/condor_blah.sh
@@ -27,7 +27,7 @@ if [ ! -d $OUTPUT_DIR ] || [ ! -w $OUTPUT_DIR ]; then
 fi
 
 # Build the filter for the history command
-CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && !isUndefined(RemoteWallClockTime) && RemoteWallClockTime =!= 0.0 "
+CONSTR="EnteredCurrentStatus >= $yesterday && EnteredCurrentStatus < $today && RemoteWallClockTime != 0 "
 
 safe_config_val CE_HOST APEL_CE_HOST
 safe_config_val BATCH_HOST APEL_BATCH_HOST


### PR DESCRIPTION
The former scripts created badly formed records (when RemoteWallClockTime is undefined) and superfluous records (when RemoteWallClockTime is defined but is zero.) This did not affect the function of the system as a whole, since aggregate accounting figures were not corrupted. But the logs contain ugly messages, due to parsing errors and/or silly zero length jobs got sent to the portal. Both classes of problem are eliminated by this patch, which checks for undefined  RemoteWallClockTime and whether RemoteWallClockTime is zero. Such pointless records are omitted. This has been tested to show that the new versions are functionally identical to the old ones in the system as a whole, but do not cause the problems described. To do this test, the old and new  versions of blah and batch data extraction scripts were run in parallel over three weeks of data. Output from the old versions was edited to remove undefined values (which would fail parsing, so are equivalent to being blank) and superfluous records (which would pass parsing but would be silly, having zero job length, and are hence equivalent to being blank.) After this operation, the output of the old and new scripts was always identical. And, since all jobs from the new scripts have non-zero run time and no undefined fields, the scripts are functionally identical but without the problems described. I’m attaching a 6 meg file to show the test details.