### PR TITLE
Differentiate between HTCondor-CE 3 and 4 upstream documentation (software-3895)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,6 @@
 HTCondor-CE
 ===========
 
-!!! info "HTCondor-CE 4 Documentation"
-    This documentation is for HTCondor-CE 4.
-    If you need documentation for HTCondor-CE 3, please consult <https://htcondor-ce.readthedocs.io/en/stable/> instead.
-
 The [HTCondor-CE](overview) software is a *job gateway* based on [HTCondor](http://htcondor.org) for Compute Elements
 (CE) belonging to a computing grid
 (e.g. [European Grid Infrastructure](https://www.egi.eu/), [Open Science Grid](https://opensciencegrid.org/)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,9 @@ repo_url: https://github.com/htcondor/htcondor-ce/
 
 theme:
   name: material
+  custom_dir: overwrite_theme
+  static_templates:
+    - main.html
 
 extra_css:
   - css/superfences.css

--- a/overwrite_theme/main.html
+++ b/overwrite_theme/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <div class="admonition info">
+        <p class="admonition-title">
+            HTCondor-CE 4 Documentation 
+        </p>
+        <p>
+            This documentation is for HTCondor-CE 4.
+            If you need documentation for HTCondor-CE 3, please consult 
+            <a href="https://htcondor-ce.readthedocs.io/en/stable/">https://htcondor-ce.readthedocs.io/en/stable/</a>
+        </p>
+    </div>
+    {{ super() }}
+{% endblock %}

--- a/overwrite_theme/main.html
+++ b/overwrite_theme/main.html
@@ -3,11 +3,11 @@
 {% block content %}
     <div class="admonition info">
         <p class="admonition-title">
-            HTCondor-CE 4 Documentation 
+            HTCondor-CE 4 Documentation
         </p>
         <p>
             This documentation is for HTCondor-CE 4.
-            If you need documentation for HTCondor-CE 3, please consult 
+            If you need documentation for HTCondor-CE 3, please consult
             <a href="https://htcondor-ce.readthedocs.io/en/stable/">https://htcondor-ce.readthedocs.io/en/stable/</a>
         </p>
     </div>


### PR DESCRIPTION
This PR overwrites the "material" theme used for the documentation to add a note to mention the version of the htcondor-ce for which the documentation was written.