### PR TITLE
Add gsi@unmapped to UNMAPPED_USERS (SOTWARE-4039)

### DIFF
--- a/config/01-ce-auth-defaults.conf
+++ b/config/01-ce-auth-defaults.conf
@@ -23,9 +23,9 @@ FRIENDLY_DAEMONS = condor@daemon.htcondor.org/$(FULL_HOSTNAME) condor@child/$(FU
 UID_DOMAIN = users.htcondor.org
 USERS = *@users.htcondor.org
 
-# Unmapped users who authenticated with GSI; they are allowed to advertise
+# Unmapped users who authenticated with GSI or SSL; they are allowed to advertise
 # to the collector, but that is all.
-UNMAPPED_USERS = *@unmapped.htcondor.org
+UNMAPPED_USERS = *@unmapped.htcondor.org, gsi@unmapped
 
 # Authz settings for each daemon.  Preferably, change the templates above
 ALLOW_READ = *

--- a/config/condor_mapfile
+++ b/config/condor_mapfile
@@ -25,7 +25,6 @@
 # The special token GSS_ASSIST_GRIDMAP indicates one should use the Globus Toolkit
 # callout mechanism (which may involve plugins such as LCMAPS or Argus).
 GSI (.*) GSS_ASSIST_GRIDMAP
-GSI "/CN=([-.A-Za-z0-9/= ]+)" \1@unmapped.htcondor.org
 SSL "/CN=([-.A-Za-z0-9/= ]+)" \1@unmapped.htcondor.org
 CLAIMTOBE .* anonymous@claimtobe
 FS "^(root|condor)$" \1@daemon.htcondor.org

--- a/config/condor_mapfile.osg
+++ b/config/condor_mapfile.osg
@@ -1,5 +1,4 @@
 GSI (.*) GSS_ASSIST_GRIDMAP
-GSI "[-.A-Za-z0-9/= ]*/CN=([-.A-Za-z0-9/= ]+)" \1@unmapped.htcondor.org
 SSL "[-.A-Za-z0-9/= ]*/CN=([-.A-Za-z0-9/= ]+)" \1@unmapped.htcondor.org
 CLAIMTOBE .* anonymous@claimtobe
 FS "^(root|condor)$" \1@daemon.htcondor.org


### PR DESCRIPTION
When GSS_ASSIST_GRIDMAP fails, it results in the authenticated
identity of "gsi@unmapped". Additionally, the failed mappings do not
fall through to other GSI lines in the mapfile so the second GSI
mapfile lines were unnecessary here.