### PR TITLE
Add APEL systemd service and timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ install(FILES config/condor-ce config/condor-ce-collector DESTINATION ${SYSCONF_
 install(FILES
   config/condor-ce.service
   config/condor-ce-collector.service
+  contrib/apelscripts/condor-ce-apel.service
+  contrib/apelscripts/condor-ce-apel.timer
   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 
 install(FILES config/condor-ce.conf config/condor-ce-collector.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/tmpfiles.d)

--- a/contrib/apelscripts/50-ce-apel-defaults.conf
+++ b/contrib/apelscripts/50-ce-apel-defaults.conf
@@ -18,11 +18,3 @@ APEL_OUTPUT_DIR = /var/lib/condor-ce/apel/
 
 # The attribute in the batch system that stores the scaling factor
 APEL_SCALING_ATTR = MachineAttrApelScaling0
-
-# Setup cron job for APEL record generation and upload
-SCHEDD_CRON_JOBLIST = $(SCHEDD_CRON_JOBLIST) APEL
-SCHEDD_CRON_APEL_MODE = Periodic
-SCHEDD_CRON_APEL_PERIOD = 24h
-SCHEDD_CRON_APEL_EXECUTABLE = /usr/share/condor-ce/condor_ce_apel.sh
-SCHEDD_CRON_APEL_KILL = True
-SCHEDD_CRON_APEL_PREFIX = APEL

--- a/contrib/apelscripts/condor-ce-apel.service
+++ b/contrib/apelscripts/condor-ce-apel.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Upload HTCondor-CE APEL records
+After=syslog.target network-online.target
+Wants=network-online.target condor-ce.service condor.service
+
+[Service]
+ExecStart=/usr/share/condor-ce/condor_ce_apel.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/apelscripts/condor-ce-apel.timer
+++ b/contrib/apelscripts/condor-ce-apel.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Upload HTCondor-CE APEL records periodically
+After=network-online.target
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=24h
+RandomizedDelaySec=3min
+Unit=condor-ce-apel.service
+
+[Install]
+WantedBy=timers.target

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -212,6 +212,8 @@ rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/config.d/50-ce-apel-defaults.conf
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_blah.sh
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_batch.sh
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_ce_apel.sh
+rm -f $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.service
+rm -f $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.timer
 %else
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/bdii/gip/provider
 mv $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider \
@@ -340,6 +342,9 @@ fi
 %{_sysconfdir}/condor/config.d/50-condor-apel.conf
 %config(noreplace) %{_sysconfdir}/condor-ce/config.d/50-ce-apel.conf
 %attr(-,root,root) %dir %{_localstatedir}/lib/condor-ce/apel/
+
+%{_unitdir}/condor-ce-apel.service
+%{_unitdir}/condor-ce-apel.timer
 %endif
 
 %files view


### PR DESCRIPTION
From #323, the APEL SchedD cron has not worked out due to various APEL directory permission issues. Replace it with a systemd service and timer.