### PR TITLE
Return full ads in get_schedd_ads() even when only querying the local pool

### DIFF
--- a/src/htcondorce/web_utils.py
+++ b/src/htcondorce/web_utils.py
@@ -71,7 +71,13 @@ def get_schedd_ads(environ):
             return [coll.query(htcondor.AdTypes.Schedd, "Name=?=%s" % classad.quote(name))[0]]
         else:
             return coll.query(htcondor.AdTypes.Schedd, "true")
-    return [coll.locate(htcondor.DaemonTypes.Schedd)]
+
+    local_schedd_minimal_ad = coll.locate(htcondor.DaemonTypes.Schedd)
+    if not local_schedd_minimal_ad or "Name" not in local_schedd_minimal_ad:
+        return []
+
+    local_schedd_ads = coll.query(htcondor.AdTypes.Schedd, "Name=?=%s" % classad.quote(local_schedd_minimal_ad["Name"]))
+    return local_schedd_ads
 
 
 def get_schedd_statuses(environ={}):


### PR DESCRIPTION
The classad that Collector.locate() returns only contains "Name" and other minimal information to contact that daemon, not any of the other attributes we use elsewhere.
Once we have the Name, query the collector again to get the full schedd ad.