### PR TITLE
Revert APEL cron (stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,10 @@ configure_file (
   "${CMAKE_CURRENT_BINARY_DIR}/config/01-ce-router-defaults.conf"
 )
 
-install(PROGRAMS src/condor-ce src/condor-ce-collector DESTINATION ${SYSCONF_INSTALL_DIR}/rc.d/init.d)
+install(PROGRAMS
+  src/condor-ce
+  src/condor-ce-collector
+  DESTINATION ${SYSCONF_INSTALL_DIR}/rc.d/init.d)
 
 install(PROGRAMS
   src/condor_ce_startup
@@ -179,7 +182,9 @@ install(FILES config/ce-status.cpf config/pilot-status.cpf DESTINATION ${SHARE_I
 install(FILES templates/index.html templates/vos.html templates/metrics.html
 	templates/health.html templates/header.html templates/pilots.html DESTINATION ${SHARE_INSTALL_PREFIX}/condor-ce/templates)
 install(FILES config/condor-ce config/condor-ce-collector DESTINATION ${SYSCONF_INSTALL_DIR}/sysconfig)
-install(FILES config/condor-ce-collector-generator.cron DESTINATION ${SYSCONF_INSTALL_DIR}/cron.d)
+install(FILES
+  config/condor-ce-collector-generator.cron
+  DESTINATION ${SYSCONF_INSTALL_DIR}/cron.d)
 install(FILES config/condor-ce-collector.logrotate  RENAME condor-ce-collector  DESTINATION ${SYSCONF_INSTALL_DIR}/logrotate.d)
 
 install(FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,8 @@ install(FILES
   config/condor-ce-collector.service
   config/condor-ce-collector-config.service
   config/condor-ce-collector-config.timer
+  contrib/apelscripts/condor-ce-apel.service
+  contrib/apelscripts/condor-ce-apel.timer
   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
 
 install(FILES config/condor-ce.conf config/condor-ce-collector.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/tmpfiles.d)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ configure_file (
 install(PROGRAMS
   src/condor-ce
   src/condor-ce-collector
+  contrib/apelscripts/condor-ce-apel
   DESTINATION ${SYSCONF_INSTALL_DIR}/rc.d/init.d)
 
 install(PROGRAMS
@@ -184,6 +185,7 @@ install(FILES templates/index.html templates/vos.html templates/metrics.html
 install(FILES config/condor-ce config/condor-ce-collector DESTINATION ${SYSCONF_INSTALL_DIR}/sysconfig)
 install(FILES
   config/condor-ce-collector-generator.cron
+  contrib/apelscripts/condor-ce-apel.cron
   DESTINATION ${SYSCONF_INSTALL_DIR}/cron.d)
 install(FILES config/condor-ce-collector.logrotate  RENAME condor-ce-collector  DESTINATION ${SYSCONF_INSTALL_DIR}/logrotate.d)
 

--- a/contrib/apelscripts/50-ce-apel-defaults.conf
+++ b/contrib/apelscripts/50-ce-apel-defaults.conf
@@ -18,11 +18,3 @@ APEL_OUTPUT_DIR = /var/lib/condor-ce/apel/
 
 # The attribute in the batch system that stores the scaling factor
 APEL_SCALING_ATTR = MachineAttrApelScaling0
-
-# Setup cron job for APEL record generation and upload
-SCHEDD_CRON_JOBLIST = $(SCHEDD_CRON_JOBLIST) APEL
-SCHEDD_CRON_APEL_MODE = Periodic
-SCHEDD_CRON_APEL_PERIOD = 24h
-SCHEDD_CRON_APEL_EXECUTABLE = /usr/share/condor-ce/condor_ce_apel.sh
-SCHEDD_CRON_APEL_KILL = True
-SCHEDD_CRON_APEL_PREFIX = APEL

--- a/contrib/apelscripts/condor-ce-apel
+++ b/contrib/apelscripts/condor-ce-apel
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# condor	This script allows for starting and stopping a HTCondor-CE collector.
+#
+# chkconfig: 2345 98 10
+# description: The HTCondor-CE collector is a central component for collecting data
+#              about deployed HTCondor-CEs.
+# processname: condor_master
+# config: /etc/condor-ce/condor_config
+# pidfile: /var/run/condor-ce/condor_master.pid
+
+### BEGIN INIT INFO
+# Provides: condor
+# Required-Start: $local_fs $network
+# Required-Stop: $local_fs $network
+# Default-Stop: 1 2 3 4 5 6
+# Short-Description: start and stop Condor
+# Description: Condor HTC computing platform
+### END INIT INFO
+
+lockfile=/var/lock/subsys/condor-ce-apel
+
+# Source function library
+. /etc/init.d/functions
+
+# Source condor-ce environment
+[ -f /usr/share/condor-ce/condor_ce_env_bootstrap ] && . /usr/share/condor-ce/condor_ce_env_bootstrap
+
+start() {
+    echo -n $"Enabling HTCondor-CE APEL cron: "
+    touch $lockfile
+    return $?
+}
+
+stop() {
+    echo -n $"Disabling HTCondor-CE APEL cron: "
+    rm -f "$lockfile"
+    return $?
+}
+
+restart() {
+    stop
+    start
+}
+
+status() {
+    if [ -f $lockfile ]; then
+        echo "HTCondor-CE APEL cron is enabled."
+        return 0
+    else
+        echo "HTCondor-CE APEL cron is disabled."
+        return 3
+    fi
+}
+
+case "$1" in
+    start)
+	start
+        RETVAL=$?
+	;;
+    stop)
+	[ $running -eq 0 ] || exit 0
+	stop
+	RETVAL=$?
+	;;
+    restart)
+        restart
+        RETVAL=$?
+        ;;
+    status)
+	status
+	RETVAL=$?
+	;;
+    *)
+	echo $"Usage: $0 {start|stop|restart|status}"
+	RETVAL=2
+esac
+
+echo $RETVAL

--- a/contrib/apelscripts/condor-ce-apel.cron
+++ b/contrib/apelscripts/condor-ce-apel.cron
@@ -1,0 +1,1 @@
+23 4 * * * root [[ ! -f /var/lock/subsys/condor-ce-apel ]] || /usr/share/condor-ce/condor_ce_apel.sh

--- a/contrib/apelscripts/condor-ce-apel.service
+++ b/contrib/apelscripts/condor-ce-apel.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Upload HTCondor-CE APEL records
+After=syslog.target network-online.target
+Wants=network-online.target condor-ce.service condor.service
+
+[Service]
+ExecStart=/usr/share/condor-ce/condor_ce_apel.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/apelscripts/condor-ce-apel.timer
+++ b/contrib/apelscripts/condor-ce-apel.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Upload HTCondor-CE APEL records periodically
+After=network-online.target
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=24h
+RandomizedDelaySec=3min
+Unit=condor-ce-apel.service
+
+[Install]
+WantedBy=timers.target

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -213,7 +213,8 @@ make %{?_smp_mflags}
 make install DESTDIR=$RPM_BUILD_ROOT
 
 %if %systemd
-rm $RPM_BUILD_ROOT%{_initrddir}/condor-ce{,-collector}
+rm $RPM_BUILD_ROOT%{_initrddir}/condor-ce
+rm $RPM_BUILD_ROOT%{_initrddir}/condor-ce-collector
 rm $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/condor-ce-collector-generator.cron
 
 %else

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -234,6 +234,8 @@ rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/config.d/50-ce-apel-defaults.conf
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_blah.sh
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_batch.sh
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_ce_apel.sh
+rm -f $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.service
+rm -f $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.timer
 %else
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/bdii/gip/provider
 mv $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider \
@@ -383,6 +385,9 @@ install -m 0755 -d -p $RPM_BUILD_ROOT/%{_sysconfdir}/condor-ce/bosco_override
 %{_sysconfdir}/condor/config.d/50-condor-apel.conf
 %config(noreplace) %{_sysconfdir}/condor-ce/config.d/50-ce-apel.conf
 %attr(-,root,root) %dir %{_localstatedir}/lib/condor-ce/apel/
+
+%{_unitdir}/condor-ce-apel.service
+%{_unitdir}/condor-ce-apel.timer
 %endif
 
 %files view

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -215,13 +215,17 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %if %systemd
 rm $RPM_BUILD_ROOT%{_initrddir}/condor-ce
 rm $RPM_BUILD_ROOT%{_initrddir}/condor-ce-collector
+rm $RPM_BUILD_ROOT%{_initrddir}/condor-ce-apel
 rm $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/condor-ce-collector-generator.cron
+rm $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/condor-ce-apel.cron
 
 %else
 rm $RPM_BUILD_ROOT%{_unitdir}/condor-ce{,-collector}.service
 rm $RPM_BUILD_ROOT%{_unitdir}/condor-ce-collector-config.service
 rm $RPM_BUILD_ROOT%{_unitdir}/condor-ce-collector-config.timer
 rm $RPM_BUILD_ROOT%{_tmpfilesdir}/condor-ce{,-collector}.conf
+rm $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.service
+rm $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.timer
 %endif
 
 %if 0%{?osg}
@@ -237,6 +241,8 @@ rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_batch.sh
 rm -f $RPM_BUILD_ROOT%{_datadir}/condor-ce/condor_ce_apel.sh
 rm -f $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.service
 rm -f $RPM_BUILD_ROOT%{_unitdir}/condor-ce-apel.timer
+rm -f $RPM_BUILD_ROOT%{_initrddir}/condor-ce-apel
+rm -f $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/condor-ce-apel.cron
 %else
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/bdii/gip/provider
 mv $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider \
@@ -387,8 +393,13 @@ install -m 0755 -d -p $RPM_BUILD_ROOT/%{_sysconfdir}/condor-ce/bosco_override
 %config(noreplace) %{_sysconfdir}/condor-ce/config.d/50-ce-apel.conf
 %attr(-,root,root) %dir %{_localstatedir}/lib/condor-ce/apel/
 
+%if %systemd
 %{_unitdir}/condor-ce-apel.service
 %{_unitdir}/condor-ce-apel.timer
+%else
+%{_initrddir}/condor-ce-apel
+%config(noreplace) %{_sysconfdir}/cron.d/condor-ce-apel.cron
+%endif
 %endif
 
 %files view


### PR DESCRIPTION
Fixes #233. Includes systemd changes cherry-picked from #330 and init/cron for EL6 support