### PR TITLE
Update the overview to use terminology from the TCS paper

### DIFF
--- a/docs/installation/htcondor-ce.md
+++ b/docs/installation/htcondor-ce.md
@@ -5,11 +5,10 @@ Installing an HTCondor-CE
     If you are installing an HTCondor-CE for the Open Science Grid (OSG), consult the
     [OSG-specific documentation](https://opensciencegrid.org/docs/compute-element/install-htcondor-ce/).
 
-The [HTCondor-CE](overview) software is a *job gateway* based on [HTCondor](http://htcondor.org) for Compute Elements
-(CE) belonging to a computing grid
-(e.g. [European Grid Infrastructure](https://www.egi.eu/), [Open Science Grid](https://opensciencegrid.org/)).
-As such, HTCondor-CE serves as an entry point for incoming grid jobs — it handles authorization and delegation of jobs
-to a grid site's local batch system.
+HTCondor-CE is a special configuration of the HTCondor software designed as a Compute Entrypoint solution for computing
+grids (e.g. [European Grid Infrastructure](https://www.egi.eu/), [Open Science Grid](https://opensciencegrid.org/)).
+It is configured to use the [Job Router daemon](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html)
+to delegate resource allocation requests by transforming and submitting them to the site’s batch system.
 See the [overview page](/overview) for more details on the features and architecture of HTCondor-CE.
 
 Use this page to learn how to install, configure, run, test, and troubleshoot HTCondor-CE from the
@@ -370,9 +369,9 @@ root@host # yum install htcondor-ce-bdii
 Next Steps
 ----------
 
-At this point, you should have an installation of HTCondor-CE that will forward grid jobs into your site's batch system
+At this point, you should have an installation of HTCondor-CE that will forward pilot jobs into your site's batch system
 unchanged.
-If you need to transform incoming grid jobs (e.g. by setting a partition, queue, or accounting group), configure the
+If you need to transform incoming pilot jobs (e.g. by setting a partition, queue, or accounting group), configure the
 [HTCondor-CE Job Router](/batch-system-integration).
 Otherwise, continue to the [this document](/verification) to start the relevant services and verify your installation.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,54 +13,51 @@ Before continuing with the overview, make sure that you are familiar with the fo
 -   Pilot jobs and factories (e.g., [GlideinWMS](http://glideinwms.fnal.gov/doc.prd/index.html),
     [PanDA](http://news.pandawms.org/), [DIRAC](https://dirac.readthedocs.io/en/latest/index.html))
 
-What is a Compute Element?
---------------------------
+What is a Compute Entrypoint?
+-----------------------------
 
-A Compute Element (CE) is the entry point for grid jobs into your local resources.
-CEs are made up of a layer of software that you install on a machine that can submit jobs into your local batch system.
-At the heart of the CE is the *job gateway* software, which is responsible for handling incoming jobs, authenticating
-and authorizing them, and delegating them to your batch system for execution.
-
-In many grids today, jobs that arrive at a CE (called *grid jobs*) are **not** end-user jobs, but rather pilot jobs
-submitted from job factories.
-Successful pilot jobs create and make available an environment for end-user jobs to match and ultimately run within
-the pilot job.
+A Compute Entrypoint (CE) is the door for remote organizations to submit requests to temporarily allocate local compute
+resources.
+These resource allocation requests are submitted as **pilot jobs** that create an environment for end-user jobs to match
+and ultimately run within the pilot job.
+CEs are made up of a thin layer of software that you install on a machine that already has the ability to submit and
+manage jobs in your local batch system.
 
 What is HTCondor-CE?
 --------------------
 
-HTCondor-CE is a special configuration of the HTCondor software designed to be a job gateway solution for computing
+HTCondor-CE is a special configuration of the HTCondor software designed as a Compute Entrypoint solution for computing
 grids (e.g. [European Grid Infrastructure](https://www.egi.eu/), [Open Science Grid](https://opensciencegrid.org/)).
 It is configured to use the [Job Router daemon](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html)
-to delegate jobs by transforming and submitting them to the site’s batch system.
+to delegate resource allocation requests by transforming and submitting them to the site’s batch system.
 
 Benefits of running the HTCondor-CE:
 
--   **Scalability:** HTCondor-CE is capable of supporting job workloads of large sites
--   **Debugging tools:** HTCondor-CE offers [many tools to help troubleshoot](/troubleshooting#htcondor-ce-troubleshooting-tools)
-    issues with jobs
--   **Routing as configuration:** HTCondor-CE’s mechanism to transform and submit jobs is customized via configuration
+-   **Scalability:** HTCondor-CE is capable of supporting ~16k concurrent RARs
+-   **Debugging tools:** HTCondor-CE offers
+    [many tools to help troubleshoot](/troubleshooting#htcondor-ce-troubleshooting-tools) issues with RARs
+-   **Routing as configuration:** HTCondor-CE’s mechanism to transform and submit RARs is customized via configuration
     variables, which means that customizations will persist across upgrades and will not involve modification of
     software internals to route jobs
 
 How Jobs Run
 ------------
 
-Once an incoming grid job is authorized, it is placed into HTCondor-CE’s scheduler where the Job Router creates a
+Once an incoming pilot job is authorized, it is placed into HTCondor-CE’s scheduler where the Job Router creates a
 transformed copy (called the *routed job*) and submits the copy to the batch system (called the *batch system job*).
-After submission, HTCondor-CE monitors the batch system job and communicates its status to the original grid job, which
+After submission, HTCondor-CE monitors the batch system job and communicates its status to the original pilot job, which
 in turn notifies the original submitter (e.g., job factory) of any updates.
-When the job completes, files are transferred along the same chain: from the batch system to the CE, then from the CE to
-the original submitter.
+When the batch job job completes, files are transferred along the same chain: from the batch system to the CE, then from
+the CE to the original submitter.
 
 ### On HTCondor batch systems
 
 For a site with an HTCondor **batch system**, the Job Router uses HTCondor protocols to place a transformed copy of the
-grid job directly into the batch system’s scheduler, meaning that the routed and batch system jobs are one and the same.
+pilot job directly into the batch system’s scheduler, meaning that the routed job is also the batch system job.
 Thus, there are three representations of your job, each with its own ID (see diagram below):
 
 -   Submitter: the HTCondor job ID in the original queue
--   HTCondor-CE: the incoming grid job’s ID
+-   HTCondor-CE: the incoming pilot job’s ID
 -   HTCondor batch system: the routed job’s ID
 
 ![HTCondor-CE with an HTCondor batch system](/img/condor_batch.png)
@@ -74,13 +71,13 @@ any configuration.
 
 ### On other batch systems
 
-For non-HTCondor batch systems, the Job Router transforms the grid job into a routed job on the CE and the routed job
+For non-HTCondor batch systems, the Job Router transforms the pilot job into a routed job on the CE and the routed job
 submits a job into the batch system via a process called the BLAHP.
 Thus, there are four representations of your job, each with its own ID (see diagram below):
 
 -   Submitter: the HTCondor job ID in the original queue
--   HTCondor-CE: the incoming grid job’s ID and the routed job’s ID
--   HTCondor batch system: the batch system’s job ID
+-   HTCondor-CE: the incoming pilot job’s ID and the routed job’s ID
+-   Non-HTCondor batch system: the batch system’s job ID
 
 Although the following figure specifies the PBS case, it applies to all non-HTCondor batch systems:
 
@@ -92,13 +89,13 @@ directory must be exported to a shared file system that is mounted on the batch 
 ### Hosted CE over SSH
 
 The Hosted CE is designed to be an [HTCondor-CE as a Service](https://en.wikipedia.org/wiki/Software_as_a_service)
-offered by central grid operations.
+offered by a central grid operations team.
 Hosted CEs submit jobs to remote clusters over SSH, providing a simple starting point for opportunistic resource
 owners that want to start contributing to a computing grid with minimal effort.
 
 ![HTCondor-CE-Bosco](/img/bosco.png)
 
-If your site intends to run over 10,000 concurrent grid jobs, you will need to host your own
+If your site intends to run over 10,000 concurrent pilot jobs, you will need to host your own
 [HTCondor-CE](/installation/htcondor-ce) because the Hosted CE has not yet been optimized for such loads.
 
 How the CE is Customized
@@ -108,9 +105,9 @@ Aside from the [basic configuration](/installation/htcondor-ce#configuring-htcon
 installation, there are two main ways to customize your CE (if you decide any customization is required at all):
 
 -   **Deciding which Virtual Organizations (VOs) are allowed to run at your site:** HTCondor-CE leverages HTCondor's
-    built-in ability to authenticate incoming jobs based on their GSI credentials, including VOMS attributes.
+    built-in ability to authenticate incoming jobs based on their GSI or OAuth token credentials.
     Additionally, HTCondor may be configured to callout to external authentication services like Argus or LCMAPS. 
--   **How to filter and transform the grid jobs to be run on your batch system:** Filtering and transforming grid jobs
+-   **How to filter and transform the pilot jobs to be run on your batch system:** Filtering and transforming pilot jobs
     (i.e., setting site-specific attributes or resource limits), requires configuration of your site’s job routes.
     For examples of common job routes, consult the [batch system integration](/configuration/batch-system-integration)
     page.
@@ -118,17 +115,14 @@ installation, there are two main ways to customize your CE (if you decide any cu
 How Security Works
 ------------------
 
-In the OSG, security depends on a PKI infrastructure involving Certificate Authorities (CAs) where CAs sign and issue
+In the grid, security depends on a PKI infrastructure involving Certificate Authorities (CAs) where CAs sign and issue
 certificates.
 When these clients and hosts wish to communicate with each other, the identities of each party is confirmed by
 cross-checking their certificates with the signing CA and establishing trust.
 
-In its default configuration, HTCondor-CE uses GSI-based authentication and authorization to verify the certificate
-chain, which will work with technologies such as LCMAPS or Argus.
-Additionally, it can be reconfigured to provide alternate authentication mechanisms such as token, Kerberos, SSL, shared
-secret, or even IP-based authentication.
-More information about authorization methods can be found
-[here](https://htcondor.readthedocs.io/en/stable/admin-manual/security.html#authentication).
+In its default configuration, HTCondor-CE supports token-based and GSI-based authentication and authorization to the
+remote submitter's credentials.
+HTCondor-CE also supports callouts to external authorization technoligies such as LCMAPS or Argus.
 
 Getting Help
 ------------

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -734,7 +734,7 @@ user@host $ condor_ce_status -any
 !!! note ""Missing" Worker Nodes"
     An HTCondor-CE will not show any worker nodes (e.g. `Machine` entries in the `condor_ce_status -any` output) if
     it does not have any running GlideinWMS pilot jobs.
-    This is expected since HTCondor-CE only forwards incoming grid jobs to your batch system and does not match jobs to
+    This is expected since HTCondor-CE only forwards incoming pilot jobs to your batch system and does not match jobs to
     worker nodes.
 
 #### Troubleshooting


### PR DESCRIPTION
This PR also includes

- Refer to all incoming jobs as pilots to hammer home the fact that the CE is designed exclusively for pilots
- Updates to supported auth methods