### PR TITLE
Fix a stacktrace that occurs when HTCONDORCE_SPEC isn't defined

### DIFF
--- a/contrib/bdii/htcondor-ce-provider
+++ b/contrib/bdii/htcondor-ce-provider
@@ -238,7 +238,7 @@ def main():
 
 
         # Get from the configuration types and values of the benchmarks
-        specs = ca.ClassAd(htcondor.param.get('HTCONDORCE_SPEC')) or []
+        specs = ca.ClassAd(htcondor.param.get('HTCONDORCE_SPEC', "[]"))
         for spec_type, spec_value in specs.items():
             spec_type = spec_type.strip().replace('_', '-')
             print(SPEC_LDIF.format(


### PR DESCRIPTION
(RT#100853)

`classad.ClassAd` only takes strings as input :(