### PR TITLE
Temporarily fixup link to OSG CE submission doc

### DIFF
--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -512,7 +512,8 @@ To disable this feature on your CE, consult
 
 ### condor_ce_submit
 
-See the [submitting to HTCondor-CE](submit-htcondor-ce) document for details.
+See the [OSG documentation for submitting to HTCondor-CE](https://opensciencegrid.org/docs/compute-element/submit-htcondor-ce/)
+for details.
 
 ### condor_ce_ping
 


### PR DESCRIPTION
Ideally I'd like to reorganize that doc and dump it under the "Central
Grid Operations" section but this will have to do for now.