### PR TITLE
Adjust APEL defaults of APEL_BATCH_HOST to lrms

### DIFF
--- a/contrib/apelscripts/50-ce-apel-defaults.conf
+++ b/contrib/apelscripts/50-ce-apel-defaults.conf
@@ -8,7 +8,7 @@
 ###############################################################################
 
 APEL_CE_HOST = $(CONDOR_HOST)
-APEL_BATCH_HOST = $(CONDOR_HOST)
+APEL_BATCH_HOST = $(JOB_ROUTER_SCHEDD2_POOL)
 
 # The CE_ID is the CE, the port, and the batch system,
 # ending with -condor to show the type of batch system.


### PR DESCRIPTION
Fixes the default APEL setting for the BATCH_HOST. This previously pointed to the CE host instead of the LRMS host.

This change relies on ``JOB_ROUTER_SCHEDD2_POOL`` pointing at the LRMS collector, which seems to be always valid when the LRMS is HTCondor.