### PR TITLE
Revert "Adjust APEL defaults of APEL_BATCH_HOST to lrms"

### DIFF
--- a/contrib/apelscripts/50-ce-apel-defaults.conf
+++ b/contrib/apelscripts/50-ce-apel-defaults.conf
@@ -8,7 +8,7 @@
 ###############################################################################
 
 APEL_CE_HOST = $(CONDOR_HOST)
-APEL_BATCH_HOST = $(JOB_ROUTER_SCHEDD2_POOL)
+APEL_BATCH_HOST = $(CONDOR_HOST)
 
 # The CE_ID is the CE, the port, and the batch system,
 # ending with -condor to show the type of batch system.

--- a/contrib/apelscripts/50-ce-apel-defaults.conf
+++ b/contrib/apelscripts/50-ce-apel-defaults.conf
@@ -8,6 +8,10 @@
 ###############################################################################
 
 APEL_CE_HOST = $(CONDOR_HOST)
+# APEL_BATCH_HOST is used to construct the unique APEL batch record,
+# combining the local condor batch ID and the relevant host. Since job
+# IDs are unique to their submit hosts, this should be tied to the CE
+# host instead of the local central manager.
 APEL_BATCH_HOST = $(CONDOR_HOST)
 
 # The CE_ID is the CE, the port, and the batch system,


### PR DESCRIPTION
This reverts commit 465221a84843c5d8ec4957c1f2dcee251e7cc643 from #371 

APEL_BATCH_HOST is used to construct the unique APEL batch record,
combining the local condor batch ID and the relevant host. Since job
IDs are unique to their submit hosts, this should be tied to the CE
host instead of the local central manager.