### PR TITLE
Allow users to unset the default home env var in the routed job

### DIFF
--- a/config/01-pilot-env-defaults.conf
+++ b/config/01-pilot-env-defaults.conf
@@ -31,3 +31,7 @@ CONDORCE_PILOT_JOB_ENV = ""
 # collector. This allows pilot jobs to advertise their startd's back
 # to the HTCondor-CE collector for auditing user payload jobs.
 DISABLE_PILOT_ADS = False
+
+# By default, HTCondor-CE sets the home directory of the job to
+# the home directory of the users on the CE host.
+USE_CE_HOME_DIR = True

--- a/config/01-pilot-env.conf
+++ b/config/01-pilot-env.conf
@@ -29,3 +29,10 @@
 # "True":
 #
 # DISABLE_PILOT_ADS = False
+
+# By default, HTCondor-CE sets the home directory of the pilot job to
+# the home directory of the users on the CE host.  If the home
+# directories of the user are different between the CE host and the
+# worker node, uncomment the following line and set it to "False":
+#
+# USE_CE_HOME_DIR = True

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -24,7 +24,11 @@ JOB_ROUTER_DEFAULTS = """JOB_ROUTER_DEFAULTS_GENERATED @=jrd
     /* Set the environment */
     copy_environment = "orig_environment";
     set_osg_environment = "@osg_environment@";
-    eval_set_environment = mergeEnvironment(join(" ", strcat("HOME=", userHome(Owner, "/")), @advertise_pilots@),
+    eval_set_environment = mergeEnvironment(join(" ",
+                                                 $(USE_CE_HOME_DIR) =?= True ?
+                                                     strcat("HOME=", userHome(Owner, "/")) :
+                                                     "",
+                                                 @advertise_pilots@),
                                             osg_environment,
                                             orig_environment,
                                             $(CONDORCE_PILOT_JOB_ENV),


### PR DESCRIPTION
Addresses #374

Tested on a fermicloud VM and the `Environment` of the routed job included or excluded `HOME` when I set `USE_CE_HOME_DIR` to `True` or `False`, respectively