### PR TITLE
Drop htcondor-ce requirement from htcondor-ce-bdii (stable)

### DIFF
--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -66,7 +66,7 @@ Requires: /usr/bin/unshare
 Group: Applications/Internet
 Summary:  GLUE 2.0 infoprovider and CE config for non-OSG sites.
 
-Requires: %{name} = %{version}-%{release}
+Requires: python2-condor
 Requires: bdii
 
 %description bdii

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -66,7 +66,8 @@ Requires: /usr/bin/unshare
 Group: Applications/Internet
 Summary:  GLUE 2.0 infoprovider and CE config for non-OSG sites.
 
-Requires: %{name} = %{version}-%{release}, bdii
+Requires: %{name} = %{version}-%{release}
+Requires: bdii
 
 %description bdii
 %{summary}


### PR DESCRIPTION
Basically the same as #384 except we don't care about Python 3 support for stable