### PR TITLE
Avoid double-counting available resources

### DIFF
--- a/contrib/bdii/htcondor-ce-provider
+++ b/contrib/bdii/htcondor-ce-provider
@@ -186,25 +186,25 @@ def main():
 
     # Query collector for the number of CPUs and batch system Collector ad
     coll = htcondor.Collector()
-    total_cores = {}
+    total_cores = 0
     topologies = {}
-    for classad in coll.query(htcondor.AdTypes.Startd, 'State=!="Owner"',
+    for classad in coll.query(htcondor.AdTypes.Startd,
+                              'State != "Owner" && SlotType != "Dynamic"',
                               ['Arch', 'OpSys', 'OpSysMajorVer', 'OpSysName',
-                               'DetectedCpus', 'DetectedMemory', 'Machine']):
+                               'TotalSlotCpus', 'TotalSlotMemory', 'Machine']):
         if not classad.get('Machine'):
             continue  # skip malformed ads where we can't provide additional information
 
         try:
-            if classad['Machine'] not in total_cores:
-                total_cores[classad['Machine']] = classad['DetectedCpus']
+            total_cores += classad['Cpus']
 
             machine = (
                 classad['Arch'].lower(),
                 classad['OpSys'].lower(),
                 classad['OpSysName'],
                 classad['OpSysMajorVer'],
-                classad['DetectedCpus'],
-                classad['DetectedMemory']
+                classad['TotalSlotCpus'],
+                classad['TotalSlotMemory']
             )
             if machine not in topologies:
                 topologies[machine] = 1
@@ -260,7 +260,7 @@ def main():
         central_manager=central_manager,
         bind_dn=bind_dn,
         version=version,
-        total_cores=sum(total_cores.values()),
+        total_cores=total_cores,
         ))
 
     ce_batch_schedd_ads = coll.query(


### PR DESCRIPTION
1. Detected* attributes contain the total available resources on a
given machine
2. Dynamic slots are carved off of partitionable slots based on job
resource requests
2. Machines may have multiple slots

So to get the total number of resources available, we can just look at
the partitionable and static slots and sum the 'TotalSlot*' attributes
to get total pool CPUs and memory

TJ says this is only theoretically correct because of backfill behavior [1] but dealing with that will make the queries really heinous. I think this should be close enough.

[1]

> In theory, but since we lie about total cpus in order to do backfill on some machines,  what you actually want to do is grab TotalSlotCpus from p-slots, and ignore static slots unless that machine has no p-slots
> similarly, sum cpus of p-slots and igore static slots unless the machine has no p-slots.