### PR TITLE
Remove jobs that exceed their requested max walltimes (HTCONDOR-80)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -59,13 +59,13 @@ COMPLETED_JOB_EXPIRATION = 30
 REMOVE_CLAUSE_3 = (JobStatus == 4 && time() - EnteredCurrentStatus > $(COMPLETED_JOB_EXPIRATION)*3600*24)
 REMOVE_REASON_3 = strcat("job completed over ", $(COMPLETED_JOB_EXPIRATION), " days ago.")
 
-# Remove jobs that
+# Remove jobs that have exceeded configured or requested max wall time
 REMOVE_CLAUSE_4 = (JobUniverse == 5 && \
                    JobStatus == 2 && \
                    time() - JobCurrentStartExecutingDate > \
-                       maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60 )
-REMOVE_REASON_4 = strcat("job exeeded allowed walltime: ", \
-                         maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60, \
+                       maxWalltime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60 )
+REMOVE_REASON_4 = strcat("job exceeded allowed walltime: ", \
+                         maxWalltime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60, \
                          "min")
 
 SYSTEM_PERIODIC_REMOVE =  $(REMOVE_CLAUSE_1) || \

--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -60,8 +60,10 @@ REMOVE_CLAUSE_3 = (JobStatus == 4 && time() - EnteredCurrentStatus > $(COMPLETED
 REMOVE_REASON_3 = strcat("job completed over ", $(COMPLETED_JOB_EXPIRATION), " days ago.")
 
 # Remove jobs that
-REMOVE_CLAUSE_4 = (JobStatus == 2 && time() - JobCurrentStartExecutingDate > \
-                                     maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60 )
+REMOVE_CLAUSE_4 = (JobUniverse == 5 && \
+                   JobStatus == 2 && \
+                   time() - JobCurrentStartExecutingDate > \
+                       maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60 )
 REMOVE_REASON_4 = strcat("job exeeded allowed walltime: ", \
                          maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60, \
                          "min")

--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -59,9 +59,17 @@ COMPLETED_JOB_EXPIRATION = 30
 REMOVE_CLAUSE_3 = (JobStatus == 4 && time() - EnteredCurrentStatus > $(COMPLETED_JOB_EXPIRATION)*3600*24)
 REMOVE_REASON_3 = strcat("job completed over ", $(COMPLETED_JOB_EXPIRATION), " days ago.")
 
+# Remove jobs that
+REMOVE_CLAUSE_4 = (JobStatus == 2 && time() - JobCurrentStartExecutingDate > \
+                                     maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60 )
+REMOVE_REASON_4 = strcat("job exeeded allowed walltime: ", \
+                         maxWalltime isnt defined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60, \
+                         "min")
+
 SYSTEM_PERIODIC_REMOVE =  $(REMOVE_CLAUSE_1) || \
                           $(REMOVE_CLAUSE_2) || \
-                          $(REMOVE_CLAUSE_3)
+                          $(REMOVE_CLAUSE_3) || \
+                          $(REMOVE_CLAUSE_4)
 
 DEFAULT_REMOVE_REASON = "input files missing."
 
@@ -70,6 +78,7 @@ SYSTEM_PERIODIC_REMOVE_REASON = \
           $(REMOVE_CLAUSE_1) ? $(REMOVE_REASON_1) : \
           $(REMOVE_CLAUSE_2) ? $(REMOVE_REASON_2) : \
           $(REMOVE_CLAUSE_3) ? $(REMOVE_REASON_3) : \
+          $(REMOVE_CLAUSE_4) ? $(REMOVE_REASON_4) : \
                                $(DEFAULT_REMOVE_REASON) \
    )
 


### PR DESCRIPTION
This doesn't quite match the logic of https://github.com/htcondor/htcondor-ce/blob/master/src/condor_ce_router_defaults#L104-L109 since admins can set `default_maxWalltime` per route but it's a start for @maxfischer2781. Ultimately I think all the max walltime logic should be executed by the `SYSTEM_PERIODIC_REMOVE` in the CE layer but that depends on whether or not `JobCurrentStartExecutingDate` in the CE job is reasonable enough to use in both the HTCondor and non-HTCondor batch system cases.

#### Context

Historically we've told pilot factories to submit jobs with [+maxWalltime](https://htcondor-ce.readthedocs.io/en/latest/remote-job-submission/#submit-file-commands) to cap the runtime (in minutes) of pilot jobs. Admins could also set `default_maxWallTime` per job route. However this is currently only supported for non-HTCondor batch systems (https://opensciencegrid.atlassian.net/browse/HTCONDOR-80).