### PR TITLE
Document enabling of CE view service

### DIFF
--- a/docs/installation/htcondor-ce.md
+++ b/docs/installation/htcondor-ce.md
@@ -308,6 +308,12 @@ To run the HTCondor-CE View, install the appropriate package and set the relevan
 
         :::console
         root@host # yum install htcondor-ce-view
+        
+1.  Enable the monitoring and webapp service in `/etc/condor-ce/config.d/05-ce-view.conf`
+
+    ``` file
+    DAEMON_LIST = $(DAEMON_LIST), CEVIEW, GANGLIAD, SCHEDD
+    ```
 
 1.  Restart the `condor-ce` service
 


### PR DESCRIPTION
The current documentation for the CE View does not document how to enable the view – it implies the view is automatically enabled. This PR expands the documentation with the required config changes.