### PR TITLE
Remove circular definition that caused condor_gangliad to thrash (HTCONDOR-161)

### DIFF
--- a/config/05-ce-view-defaults.conf
+++ b/config/05-ce-view-defaults.conf
@@ -22,7 +22,7 @@ GANGLIA_GMETRIC=/usr/share/condor-ce/condor_ce_metric
 GANGLIA_SEND_DATA_FOR_ALL_HOSTS=true
 
 # Make sure GangliaD uses the same collector as CE View
-GANGLIAD.COLLECTOR_HOST = $(HTCONDORCE_VIEW_POOL:$(COLLECTOR_HOST))
+GANGLIAD.COLLECTOR_HOST = $(HTCONDORCE_VIEW_POOL:$(CONDOR_HOST):$(PORT))
 
 # Define the CE View daemon binary and logging.
 CEVIEW=/usr/share/condor-ce/condor_ce_view


### PR DESCRIPTION
My test container's much happier now:

```
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND                                                                                                              
      1 root      20   0   11708   2448   2272 S   0.0  0.0   0:00.00 runme.sh                                                                                                             
      7 root      20   0   11844   2884   2456 S   0.0  0.0   0:00.04 bash                                                                                                                 
     18 condor    20   0   72036  12060  10004 S   0.0  0.1   0:00.77 condor_master                                                                                                        
    106 root      20   0    4400    760    684 S   0.0  0.0   0:00.00 cat                                                                                                                  
    306 root      20   0   22824   4056   2836 S   0.0  0.0   0:00.28 condor_procd                                                                                                         
    308 condor    20   0   44492   9336   8560 S   0.0  0.1   0:00.25 condor_shared_p                                                                                                      
    310 condor    20   0   45148   9952   8936 S   0.0  0.1   0:00.28 condor_collecto                                                                                                      
    313 condor    20   0   46604  11368   9696 S   0.0  0.1   0:00.31 condor_schedd                                                                                                        
    314 condor    20   0   64548  10872   9488 S   0.0  0.1   0:00.33 condor_job_rout                                                                                                      
    321 condor    20   0   45092  10028   8624 S   0.0  0.1   0:00.29 condor_gangliad                                                                                                      
    369 root      20   0   56220   3792   3236 R   0.0  0.0   0:00.01 top                                                                                                                  

[root@2539ab0813bc config.d]# condor_ce_config_val -v gangliad.collector_host
GANGLIAD.COLLECTOR_HOST = 2539ab0813bc:9619
 # at: /etc/condor-ce/config.d/99-local.conf, line 6
 # raw: GANGLIAD.COLLECTOR_HOST = $(HTCONDORCE_VIEW_POOL:$(CONDOR_HOST):$(PORT))
```