### PR TITLE
Add development Dockerfile; minor Python 3 fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,34 @@ branch contains the previous version.
 
 - [Development](https://htcondor-ce.readthedocs.io/en/latest/): HTCondor-CE 4
 - [Stable](https://htcondor-ce.readthedocs.io/en/stable/): HTCondor-CE 3
+
+Development
+-----------
+
+1.  Build the development container:
+
+        $ docker build -t htcondor-ce-dev -f tests/Dockerfile.dev .
+
+    Optionally, specify the following build arguments:
+
+        -  `EL`: CentOS base image to use for the build.
+           Accepted values: `8` or `7` (default)
+        -  `BUILD_ENV`: specifies the repositories to use for HTCondor/BLAH dependencies.
+           Accepted values: `osg` or `uw_build` (default)
+
+2.  Run the container with the following:
+
+        $ docker run -d \
+                     --name my-htcondor-ce \
+                     -v ${PWD}:/src/htcondor-ce \
+                     -p 9619:9619 \
+                     -p 8080:80 \
+                     htcondor-ce-dev
+
+3.  Make changes to the source, apply them, and reconfigure the CE:
+
+        $ docker exec my-htcondor-ce \
+                 /bin/sh -c \
+                   "cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 && \
+                    make install && \
+                    condor_ce_restart -fast"

--- a/config/01-common-collector-defaults.conf
+++ b/config/01-common-collector-defaults.conf
@@ -13,4 +13,4 @@ STATUS_DEFAULT_SCHEDD_PRINT_FORMAT_FILE=/usr/share/condor-ce/ce-status.cpf
 STATUS_DEFAULT_STARTD_PRINT_FORMAT_FILE=/usr/share/condor-ce/pilot-status.cpf
 
 # enable python plugins
-COLLECTOR.PLUGINS = /usr/libexec/condor/libcollector_python_plugin.so
+COLLECTOR.PLUGINS = /usr/libexec/condor/libcollector_python3_plugin.so

--- a/tests/Dockerfile.dev
+++ b/tests/Dockerfile.dev
@@ -1,0 +1,21 @@
+ARG EL=7
+
+FROM centos:centos$EL
+
+# "ARG EL" needs to be here again because the previous instance has gone out of scope.
+ARG EL=7
+ARG BUILD_ENV=uw_build
+
+# Build and install RPMs using existing scripts so we don't have to
+# reproduce dependencies
+COPY . /src/htcondor-ce/
+
+# Build and install RPM scripts expect the spec file bin
+# htcondor-ce/rpm/htcondor-ce.spec
+WORKDIR /src/
+RUN htcondor-ce/tests/build_rpms.sh $EL $BUILD_ENV
+RUN htcondor-ce/tests/install_rpms.sh $BUILD_ENV
+
+WORKDIR htcondor-ce
+
+ENTRYPOINT ["/src/htcondor-ce/tests/runme.sh"]


### PR DESCRIPTION
Submitting this PR before I start performing major surgery on the CE View bits.

The fixup is required for HTCondor-CE to be able to run `audit_payloads` as a collector plugin.
