### PR TITLE
Fixup collector stacktrace; add a UW build check for the CE collector

### DIFF
--- a/tests/install_rpms.sh
+++ b/tests/install_rpms.sh
@@ -15,7 +15,7 @@ useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
         -u 64 -c "Owner of HTCondor Daemons" condor
 
 RPM_LOCATION=/tmp/rpmbuild/RPMS/noarch
-[[ $BUILD_ENV == osg ]] && extra_repos='--enablerepo=osg-development'
+[[ $BUILD_ENV == osg ]] && extra_repos='--enablerepo=osg-upcoming-development'
 
 package_version=`grep Version htcondor-ce/rpm/htcondor-ce.spec | awk '{print $2}'`
 yum localinstall -y $RPM_LOCATION/htcondor-ce-${package_version}* \

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -50,6 +50,7 @@ function run_integration_tests {
     # TODO: Change this to voms-proxy-init to test VOMS attr mapping
     pushd /tmp
     sudo -u $test_user /bin/sh -c "echo $test_user | grid-proxy-init -pwstdin"
+    sudo -u $test_user condor_ce_status -any
     sudo -u $test_user condor_ce_trace -d $(hostname)
     test_exit=$?
     popd


### PR DESCRIPTION
Running OSG tests against 8.9 fixes the collector stacktrace since 8.9 provides better Python 3 support for the collector plugins.

Note that OSG CE View tests are still failing but I'll tackle that in a separate PR