### PR TITLE
Do not set HOME in the default job environment (HTCONDOR-176)

### DIFF
--- a/config/01-pilot-env-defaults.conf
+++ b/config/01-pilot-env-defaults.conf
@@ -32,6 +32,6 @@ CONDORCE_PILOT_JOB_ENV = ""
 # to the HTCondor-CE collector for auditing user payload jobs.
 DISABLE_PILOT_ADS = False
 
-# By default, HTCondor-CE sets the home directory of the job to
-# the home directory of the users on the CE host.
-USE_CE_HOME_DIR = True
+# By default, do not set the home directory of the job to
+# the home directory of the users on the CE host (HTCONDOR-176)
+USE_CE_HOME_DIR = False

--- a/config/01-pilot-env.conf
+++ b/config/01-pilot-env.conf
@@ -30,9 +30,8 @@
 #
 # DISABLE_PILOT_ADS = False
 
-# By default, HTCondor-CE sets the home directory of the pilot job to
-# the home directory of the users on the CE host.  If the home
-# directories of the user are different between the CE host and the
-# worker node, uncomment the following line and set it to "False":
+# Set HOME in the routed job's environment to HOME of the user on the
+# HTCondor-CE host (default: False). To enable this feature, uncomment
+# the following line and set it to "True":
 #
-# USE_CE_HOME_DIR = True
+# USE_CE_HOME_DIR = False


### PR DESCRIPTION
This flips the switch here: https://github.com/htcondor/htcondor-ce/blob/V5-branch/src/condor_ce_router_defaults#L28-L30