### PR TITLE
Use GlobalJobId as unique job identifier

### DIFF
--- a/contrib/apelscripts/condor_batch.sh
+++ b/contrib/apelscripts/condor_batch.sh
@@ -32,8 +32,7 @@ safe_config_val SCALING_ATTR APEL_SCALING_ATTR
 safe_config_val BATCH_HOST APEL_BATCH_HOST
 
 TZ=GMT condor_history -constraint "$CONSTR" \
-    -format "%s" clusterId \
-    -format ".%s_${BATCH_HOST}|" ProcId \
+    -format "%s|" GlobalJobId \
     -format "%s|" Owner \
     -format "%d|" RemoteWallClockTime \
     -format "%d|" RemoteUserCpu \

--- a/contrib/apelscripts/condor_blah.sh
+++ b/contrib/apelscripts/condor_blah.sh
@@ -39,7 +39,6 @@ TZ=GMT condor_history -const "$CONSTR" \
  -format "\"userFQAN=%s\" " x509UserProxyFirstFQAN \
  -format "\"ceID=${CE_ID}\" " EMPTY \
  -format "\"jobID=%v_${CE_HOST}\" " RoutedFromJobId \
- -format "\"lrmsID=%v" clusterId \
- -format ".%v_${BATCH_HOST}\" " ProcId \
+ -format "\"lrmsID=%s\" " GlobalJobId \
  -format "\"localUser=%s\"\n"  Owner  > $OUTPUT_FILE
 


### PR DESCRIPTION
Instead of making up a custom LRMS job identifier, use the Condor-defined GlobalJobId.
This doesn't introduce arbitrary convention on the JobId format.
It also allows using the field directly in condor_history constraints.