### PR TITLE
Use job attribute BatchRuntime to set max wallclock time. HTCONDOR-80

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -63,9 +63,9 @@ REMOVE_REASON_3 = strcat("job completed over ", $(COMPLETED_JOB_EXPIRATION), " d
 REMOVE_CLAUSE_4 = (JobUniverse == 5 && \
                    JobStatus == 2 && \
                    time() - JobCurrentStartExecutingDate > \
-                       maxWalltime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60 )
+                       maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60 )
 REMOVE_REASON_4 = strcat("job exceeded allowed walltime: ", \
-                         maxWalltime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : maxWalltime*60, \
+                         maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60, \
                          "min")
 
 SYSTEM_PERIODIC_REMOVE =  $(REMOVE_CLAUSE_1) || \

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -113,17 +113,20 @@ JOB_ROUTER_DEFAULTS = """JOB_ROUTER_DEFAULTS_GENERATED @=jrd
                                                        default_xcount,
                                                        1));
 
-    set_CondorCE = 1;
+    /* BatchRuntime is in seconds but users configure default_maxWallTime and ROUTED_JOB_MAX_TIME in minutes */
+    copy_BatchRuntime = "orig_BatchRuntime";
+    set_BatchRuntime = ifThenElse(maxWallTime isnt undefined,
+                                  60*maxWallTime,
+                                  ifThenElse(orig_BatchRuntime isnt undefined,
+                                             orig_BatchRuntime,
+                                             ifThenElse(default_maxWallTime isnt undefined,
+                                                        60*default_maxWallTime,
+                                                        60*$(ROUTED_JOB_MAX_TIME))));
 
-    /* WallTime is in seconds but users configure default_maxWallTime and ROUTED_JOB_MAX_TIME in minutes */
-    set_WallTime = ifThenElse(maxWallTime isnt undefined,
-                              60*maxWallTime,
-                              ifThenElse(default_maxWallTime isnt undefined,
-                                         60*default_maxWallTime,
-                                         60*$(ROUTED_JOB_MAX_TIME)));
+    set_CondorCE = 1;
     eval_set_CERequirements = ifThenElse(default_CERequirements isnt undefined,
-                                         strcat(default_CERequirements, ",Walltime,CondorCE"),
-                                         "Walltime,CondorCE");
+                                         strcat(default_CERequirements, ",CondorCE"),
+                                         "CondorCE");
 
     copy_OnExitHold = "orig_OnExitHold";
     set_OnExitHold = ifThenElse(orig_OnExitHold isnt undefined,


### PR DESCRIPTION
Instead of setting Walltime as a CERequirements attribute in the routed
job, set BatchRuntime (now supported by HTCondor and the blahp).
Also, recognize and use BatchRuntime in the source job ad.