### PR TITLE
Add HTCondor-CE version information to condor_ce_version

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -92,7 +92,7 @@ ROUTED_JOB_MAX_TIME = 4320
 JOB_ROUTER_NAME = htcondor-ce
 
 # The version of the HTCondor-CE.  Useful for debugging purposes.
-HTCondorCEVersion = "@HTCONDORCE_VERSION@"
+HTCondorCEVersion = @HTCONDORCE_VERSION@
 grid_resource = strcat("condor ", ifThenElse(size("$(SCHEDD_NAME)") > 0, "$(SCHEDD_NAME)", "$(FULL_HOSTNAME)"), " ", "$(COLLECTOR_HOST)")
 SCHEDD_ATTRS = $(SCHEDD_ATTRS) HTCondorCEVersion grid_resource
 

--- a/src/condor_ce_version
+++ b/src/condor_ce_version
@@ -2,4 +2,6 @@
 
 . /usr/share/condor-ce/condor_ce_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
+
+echo "\$HTCondorCEVersion: $(condor_ce_config_val HTCondorCEVersion) \$"
 exec condor_version "$@"


### PR DESCRIPTION
Currently, it only prints the HTCondor version, which is helpful but not quite complete.