### PR TITLE
SchedD attrs must be enclosed by double-quoted strings

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -92,7 +92,7 @@ ROUTED_JOB_MAX_TIME = 4320
 JOB_ROUTER_NAME = htcondor-ce
 
 # The version of the HTCondor-CE.  Useful for debugging purposes.
-HTCondorCEVersion = @HTCONDORCE_VERSION@
+HTCondorCEVersion = "@HTCONDORCE_VERSION@"
 grid_resource = strcat("condor ", ifThenElse(size("$(SCHEDD_NAME)") > 0, "$(SCHEDD_NAME)", "$(FULL_HOSTNAME)"), " ", "$(COLLECTOR_HOST)")
 SCHEDD_ATTRS = $(SCHEDD_ATTRS) HTCondorCEVersion grid_resource
 

--- a/src/condor_ce_version
+++ b/src/condor_ce_version
@@ -3,5 +3,5 @@
 . /usr/share/condor-ce/condor_ce_env_bootstrap
 export GSI_AUTHZ_CONF=/dev/null
 
-echo "\$HTCondorCEVersion: $(condor_ce_config_val HTCondorCEVersion) \$"
+echo "\$HTCondorCEVersion: $(condor_ce_config_val HTCondorCEVersion | tr -d \") \$"
 exec condor_version "$@"


### PR DESCRIPTION
Fixes the following issue:

```
03/17/21 13:52:03 (D_ALWAYS) CONFIGURATION PROBLEM: Failed to insert ClassAd attribute HTCondorCEVersion = 5.0.0.  The most common reason for this is that you forgot to quote a string value in the list of attributes being added to the SCHEDD ad.
```