### PR TITLE
Fixup walltime removal expression (HTCONDOR-350)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -66,7 +66,7 @@ REMOVE_CLAUSE_4 = (JobUniverse == 5 && \
                        maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60 )
 REMOVE_REASON_4 = strcat("job exceeded allowed walltime: ", \
                          maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60, \
-                         "min")
+                         " minutes.")
 
 SYSTEM_PERIODIC_REMOVE =  $(REMOVE_CLAUSE_1) || \
                           $(REMOVE_CLAUSE_2) || \

--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -62,7 +62,7 @@ REMOVE_REASON_3 = strcat("job completed over ", $(COMPLETED_JOB_EXPIRATION), " d
 # Remove jobs that have exceeded configured or requested max wall time
 REMOVE_CLAUSE_4 = (JobUniverse == 5 && \
                    JobStatus == 2 && \
-                   time() - JobCurrentStartExecutingDate > \
+                   time() - JobCurrentStartDate > \
                        maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60 )
 REMOVE_REASON_4 = strcat("job exceeded allowed walltime: ", \
                          maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60, \


### PR DESCRIPTION
It appears that JobCurrentStartExecutingDate does not get set in the
job ad so the expression nearly evaluates to True unless the admin
sets their max walltime to 50-some years