### PR TITLE
Ensure that we have the expected order of operations (HTCONDOR-350)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -62,8 +62,8 @@ REMOVE_REASON_3 = strcat("job completed over ", $(COMPLETED_JOB_EXPIRATION), " d
 # Remove jobs that have exceeded configured or requested max wall time
 REMOVE_CLAUSE_4 = (JobUniverse == 5 && \
                    JobStatus == 2 && \
-                   time() - JobCurrentStartDate > \
-                       maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60 )
+                   (time() - JobCurrentStartDate) > \
+                       (maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60) )
 REMOVE_REASON_4 = strcat("job exceeded allowed walltime: ", \
                          maxWalltime is undefined ? (BatchRuntime is undefined ? $(ROUTED_JOB_MAX_TIME)*60 : BatchRuntime) : maxWalltime*60, \
                          " minutes.")


### PR DESCRIPTION
Otherwise the expression evaluates to an int, which
SYSTEM_PERIODIC_REMOVE evaluates to True:

```
$ condor_ce_history -match 1 -format '%v\n' 'EnteredCurrentStatus - JobCurrentStartDate > maxWalltime is undefined ? 4320*60 : maxWalltime*60'
259200
$ condor_ce_history -match 1 -format '%v\n' '(EnteredCurrentStatus - JobCurrentStartDate) > (maxWalltime is undefined ? 4320*60 : maxWalltime*60)'
false
```