### PR TITLE
cleaner way to give batch runtime an ultimate default (HTCONDOR-243)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -264,10 +264,10 @@ JOB_ROUTER_TRANSFORM_BatchRuntime @=jrt
     elif defined default_maxWallTime
         def_walltime = 60*$(default_maxWallTime)
     else
-        def_walltime = 60*$(ROUTED_JOB_MAX_TIME)
+        def_walltime = 60*$(ROUTED_JOB_MAX_TIME:72*60)
     endif
 
-    SET BatchRuntime $(def_walltime) ?: 259200
+    SET BatchRuntime $(def_walltime)
 @jrt
 
 


### PR DESCRIPTION
Current code will never hit the default side of ?:  it will simply not parse instead.