### PR TITLE
Disable EL8 builds; add RPM build validation to PR CI

### DIFF
--- a/.github/workflows/build_rpms.yaml
+++ b/.github/workflows/build_rpms.yaml
@@ -1,0 +1,33 @@
+name: Test building of HTCondor-CE RPMs
+on: [pull_request]
+
+jobs:
+  build-rpms-and-upload:
+    runs-on: ubuntu-latest
+    if: startsWith(github.repository, 'htcondor/')
+    strategy:
+      matrix:
+        dver: [7]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare Docker
+        run: |
+          echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null &&
+            sudo service docker restart
+
+      - name: Start CentOS ${{ matrix.dver}} image
+        run: |
+          docker run --detach --env "container=docker" \
+                 --name $GITHUB_SHA \
+                 --volume `pwd`:/htcondor-ce:rw \
+                 centos:centos${{ matrix.dver }} \
+                 /usr/sbin/init
+
+      - name: Build CHTC EL${{ matrix.dver }} RPMs
+        run: |
+          docker exec $GITHUB_SHA \
+                 /bin/bash -xc \
+                   "/htcondor-ce/tests/build_rpms.sh \
+                     ${{ matrix.dver }} \
+                     uw_build"

--- a/.github/workflows/upload_rpms.yaml
+++ b/.github/workflows/upload_rpms.yaml
@@ -11,7 +11,7 @@ jobs:
     if: startsWith(github.repository, 'htcondor/')
     strategy:
       matrix:
-        dver: [7, 8]
+        dver: [7]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
4.5.0 RPM builds failed due to EL8, which we don't support in v4 anyway