### PR TITLE
Update condor_ce_startup

### DIFF
--- a/src/condor_ce_startup
+++ b/src/condor_ce_startup
@@ -14,7 +14,7 @@ fail() {
 # Verify that required dirs are owned by condor:condor (SOFTWARE-2806)
 required_dirs="/var/run/condor-ce /var/log/condor-ce /var/log/condor-ce/user /var/lib/condor-ce /var/lib/condor-ce/spool
 /var/lib/condor-ce/execute /var/lock/condor-ce /var/lock/condor-ce/user"
-bad_dirs=$(stat --format "%n (%U:%G)" $required_dirs | awk '$2 != "(condor:condor)" {print $0}')
+bad_dirs=$(stat --format "%n %U" $required_dirs | awk '$2 != "condor" {print $0}')
 [ -z "$bad_dirs" ] || fail 1 "The following directories are not owned by the condor user/group:\n$bad_dirs"
 
 # Skip sanity checks if running as a central collector

--- a/src/condor_ce_startup
+++ b/src/condor_ce_startup
@@ -15,7 +15,7 @@ fail() {
 required_dirs="/var/run/condor-ce /var/log/condor-ce /var/log/condor-ce/user /var/lib/condor-ce /var/lib/condor-ce/spool
 /var/lib/condor-ce/execute /var/lock/condor-ce /var/lock/condor-ce/user"
 bad_dirs=$(stat --format "%n %U" $required_dirs | awk '$2 != "condor" {print $0}')
-[ -z "$bad_dirs" ] || fail 1 "The following directories are not owned by the condor user/group:\n$bad_dirs"
+[ -z "$bad_dirs" ] || fail 1 "The following directories are not owned by the condor user:\n$bad_dirs"
 
 # Skip sanity checks if running as a central collector
 if [ "$1" != "collector" ]; then


### PR DESCRIPTION
For sites where the user 'condor' has a primary group not named 'condor', the verification will fail, therefore prevents condor-ce from starting. The change is to loose it, only verify the required dirs are owned by 'condor' user, regardless of the group name.