### PR TITLE
Fix collector plugin path for HTCondor 8.9.11+ (HTCONDOR-400)

### DIFF
--- a/config/01-common-collector-defaults.conf
+++ b/config/01-common-collector-defaults.conf
@@ -13,4 +13,4 @@ STATUS_DEFAULT_SCHEDD_PRINT_FORMAT_FILE=/usr/share/condor-ce/ce-status.cpf
 STATUS_DEFAULT_STARTD_PRINT_FORMAT_FILE=/usr/share/condor-ce/pilot-status.cpf
 
 # enable python plugins
-COLLECTOR.PLUGINS = /usr/libexec/condor/libcollector_python3_plugin.so
+COLLECTOR.PLUGINS = /usr/libexec/condor/libcollector_python_plugin.cpython-36m-x86_64-linux-gnu.so


### PR DESCRIPTION
Fixes this issue here (https://github.com/htcondor/htcondor-ce/runs/2273421329?check_suite_focus=true#step:12:200)

```
04/05/21 22:17:30 (D_ALWAYS) Failed to load plugin: /usr/libexec/condor/libcollector_python3_plugin.so reason: /usr/libexec/condor/libcollector_python3_plugin.so: cannot open shared object file: No such file or directory
```

Name grabbed from the EL7 base container:

```
$ podman run --rm -it htcondor/base:el7 /bin/sh -c "ls -l /usr/libexec/condor/libcollector*.so"
-rwxr-xr-x. 1 root root 44640 Mar 30 04:45 /usr/libexec/condor/libcollector_python_plugin.cpython-36m-x86_64-linux-gnu.so
-rwxr-xr-x. 1 root root 44608 Mar 30 04:45 /usr/libexec/condor/libcollector_python_plugin.so
```