### PR TITLE
Update packaging for 5.1.0; drop (noreplace) for condor_mapfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(condor-ce NONE)
 
 cmake_minimum_required(VERSION 2.6)
 
-set( HTCONDORCE_VERSION "5.0.0" CACHE INTERNAL "Version of the HTCondor-CE" )
+set( HTCONDORCE_VERSION "5.1.0" CACHE INTERNAL "Version of the HTCondor-CE" )
 
 find_package(PkgConfig)
 

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -496,7 +496,7 @@ fi
 %dir %{_datadir}/condor-ce/mapfiles.d
 %config %{_datadir}/condor-ce/mapfiles.d/50-common-default.conf
 
-%config(noreplace) %{_sysconfdir}/condor-ce/condor_mapfile
+%config %{_sysconfdir}/condor-ce/condor_mapfile
 %config(noreplace) %{_sysconfdir}/condor-ce/mapfiles.d/10-gsi.conf
 %config(noreplace) %{_sysconfdir}/condor-ce/mapfiles.d/50-gsi-callout.conf
 

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -2,7 +2,7 @@
 #define gitrev osg
 
 Name: htcondor-ce
-Version: 5.0.0
+Version: 5.1.0
 Release: 1%{?gitrev:.%{gitrev}git}%{?dist}
 Summary: A framework to run HTCondor as a CE
 BuildArch: noarch
@@ -564,7 +564,15 @@ fi
 
 %changelog
 * Tue Mar 30 2021 Mark Coatsworth <coatsworth@cs.wisc.edu> - 5.1.0-1
-- APEL reporting scripts now use PER_JOB_HISTORY_DIR to collect job data. (HTCONDOR-293)
+- Fix an issue where the CE removed running jobs prematurely (HTCONDOR-350)
+- Add optional job router transform syntax (HTCONDOR-243)
+- Add username and X.509 accounting group mapfiles for use by job router transforms (HTCONDOR-187)
+- Replace custom mappings in condor_mapfile with /etc/condor-ce/mapfiles.d/ (HTCONDOR-244)
+- Require regular expressions in the second field of the unified mapfile be enclosed by '/'(HTCONDOR-244)
+- Update maxWallTime logic to accept BatchRuntime (HTCONDOR-80)
+- Append SSL to the default authentication methods list (HTCONDOR-366)
+- APEL reporting scripts now use the local HTCondor's PER_JOB_HISTORY_DIR to collect job data. (HTCONDOR-293)
+- Update HTCondor-CE registry app to Python 3 (HTCONDOR-307)
 
 * Thu Feb 11 2021 Brian Lin <blin@cs.wisc.edu> - 5.0.0-1
 - Add Python 3 and EL8 support (HTCondor-13)


### PR DESCRIPTION
We can do the latter since we will only ship 5.x along with 9.0.x in the CHTC and OSG 3.5 upcoming/3.6 Yum repos