### PR TITLE
Fix default transform routes (HTCONDOR-243)

### DIFF
--- a/config/02-ce-bosco-defaults.conf
+++ b/config/02-ce-bosco-defaults.conf
@@ -18,7 +18,7 @@ JOB_ROUTER_ENTRIES = \
    ]
 
 
-JOB_ROUTER_ROUTE_Local_BOSCO @=jrt
+JOB_ROUTER_ROUTE_Local_BOSCO_Transform @=jrt
   TargetUniverse = 9
   GridResource = "batch $(BOSCO_RMS) $(BOSCO_ENDPOINT)"
 @jrt

--- a/config/02-ce-bosco-defaults.conf
+++ b/config/02-ce-bosco-defaults.conf
@@ -16,9 +16,3 @@ JOB_ROUTER_ENTRIES = \
      TargetUniverse = 9; \
      name = "Local_BOSCO"; \
    ]
-
-
-JOB_ROUTER_ROUTE_Local_BOSCO_Transform @=jrt
-  TargetUniverse = 9
-  GridResource = "batch $(BOSCO_RMS) $(BOSCO_ENDPOINT)"
-@jrt

--- a/config/02-ce-bosco.conf
+++ b/config/02-ce-bosco.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES = \
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_BOSCO_Transform @=jrt
+# JOB_ROUTER_ROUTE_SSH_Endpoint @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch $(BOSCO_RMS) $(BOSCO_ENDPOINT)"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_BOSCO_Transform
+# JOB_ROUTER_ROUTE_NAMES = SSH_Endpoint

--- a/config/02-ce-bosco.conf
+++ b/config/02-ce-bosco.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES = \
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_BOSCO @=jrt
+# JOB_ROUTER_ROUTE_Local_BOSCO_Transform @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch $(BOSCO_RMS) $(BOSCO_ENDPOINT)"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_BOSCO
+# JOB_ROUTER_ROUTE_NAMES = Local_BOSCO_Transform

--- a/config/02-ce-condor-defaults.conf
+++ b/config/02-ce-condor-defaults.conf
@@ -19,11 +19,6 @@ JOB_ROUTER_ENTRIES @=jre
 @jre
 
 
-JOB_ROUTER_ROUTE_Local_Condor_Transform @=jrt
-  TargetUniverse = 5
-@jrt
-
-
 JOB_ROUTER_SCHEDD2_SPOOL=/var/lib/condor/spool
 JOB_ROUTER_SCHEDD2_NAME=$(FULL_HOSTNAME)
 JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618

--- a/config/02-ce-condor-defaults.conf
+++ b/config/02-ce-condor-defaults.conf
@@ -19,7 +19,7 @@ JOB_ROUTER_ENTRIES @=jre
 @jre
 
 
-JOB_ROUTER_ROUTE_Local_Condor @=jrt
+JOB_ROUTER_ROUTE_Local_Condor_Transform @=jrt
   TargetUniverse = 5
 @jrt
 

--- a/config/02-ce-condor.conf
+++ b/config/02-ce-condor.conf
@@ -26,11 +26,11 @@ JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_Condor_Transform @=jrt
+# JOB_ROUTER_ROUTE_Condor_Pool @=jrt
 #   TargetUniverse = 5
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_Condor_Transform
+# JOB_ROUTER_ROUTE_NAMES = Condor_Pool
 
 
 # If using the new-style JobRouter configuration above, uncomment the following

--- a/config/02-ce-condor.conf
+++ b/config/02-ce-condor.conf
@@ -26,11 +26,11 @@ JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_Condor @=jrt
+# JOB_ROUTER_ROUTE_Local_Condor_Transform @=jrt
 #   TargetUniverse = 5
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_Condor
+# JOB_ROUTER_ROUTE_NAMES = Local_Condor_Transform
 
 
 # If using the new-style JobRouter configuration above, uncomment the following

--- a/config/02-ce-lsf-defaults.conf
+++ b/config/02-ce-lsf-defaults.conf
@@ -18,7 +18,7 @@ JOB_ROUTER_ENTRIES @=jre
 @jre
 
 
-JOB_ROUTER_ROUTE_Local_LSF @=jrt
+JOB_ROUTER_ROUTE_Local_LSF_Transform @=jrt
   TargetUniverse = 9
   GridResource = "batch lsf"
 @jrt

--- a/config/02-ce-lsf-defaults.conf
+++ b/config/02-ce-lsf-defaults.conf
@@ -16,9 +16,3 @@ JOB_ROUTER_ENTRIES @=jre
   name = "Local_LSF";
 ]
 @jre
-
-
-JOB_ROUTER_ROUTE_Local_LSF_Transform @=jrt
-  TargetUniverse = 9
-  GridResource = "batch lsf"
-@jrt

--- a/config/02-ce-lsf.conf
+++ b/config/02-ce-lsf.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_LSF_Transform @=jrt
+# JOB_ROUTER_ROUTE_LSF_Cluster @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch lsf"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_LSF_Transform
+# JOB_ROUTER_ROUTE_NAMES = LSF_Cluster

--- a/config/02-ce-lsf.conf
+++ b/config/02-ce-lsf.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_LSF @=jrt
+# JOB_ROUTER_ROUTE_Local_LSF_Transform @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch lsf"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_LSF
+# JOB_ROUTER_ROUTE_NAMES = Local_LSF_Transform

--- a/config/02-ce-pbs-defaults.conf
+++ b/config/02-ce-pbs-defaults.conf
@@ -16,9 +16,3 @@ JOB_ROUTER_ENTRIES @=jre
   name = "Local_PBS";
 ]
 @jre
-
-
-JOB_ROUTER_ROUTE_Local_PBS_Transform @=jrt
-  TargetUniverse = 9
-  GridResource = "batch pbs"
-@jrt

--- a/config/02-ce-pbs-defaults.conf
+++ b/config/02-ce-pbs-defaults.conf
@@ -18,7 +18,7 @@ JOB_ROUTER_ENTRIES @=jre
 @jre
 
 
-JOB_ROUTER_ROUTE_Local_PBS @=jrt
+JOB_ROUTER_ROUTE_Local_PBS_Transform @=jrt
   TargetUniverse = 9
   GridResource = "batch pbs"
 @jrt

--- a/config/02-ce-pbs.conf
+++ b/config/02-ce-pbs.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_PBS @=jrt
+# JOB_ROUTER_ROUTE_Local_PBS_Transform @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch pbs"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_PBS
+# JOB_ROUTER_ROUTE_NAMES = Local_PBS_Transform

--- a/config/02-ce-pbs.conf
+++ b/config/02-ce-pbs.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_PBS_Transform @=jrt
+# JOB_ROUTER_ROUTE_PBS_Cluster @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch pbs"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_PBS_Transform
+# JOB_ROUTER_ROUTE_NAMES = PBS_Cluster

--- a/config/02-ce-sge-defaults.conf
+++ b/config/02-ce-sge-defaults.conf
@@ -16,9 +16,3 @@ JOB_ROUTER_ENTRIES @=jre
   name = "Local_SGE";
 ]
 @jre
-
-
-JOB_ROUTER_ROUTE_Local_SGE_Transform @=jrt
-  TargetUniverse = 9
-  GridResource = "batch sge"
-@jrt

--- a/config/02-ce-sge-defaults.conf
+++ b/config/02-ce-sge-defaults.conf
@@ -18,7 +18,7 @@ JOB_ROUTER_ENTRIES @=jre
 @jre
 
 
-JOB_ROUTER_ROUTE_Local_SGE @=jrt
+JOB_ROUTER_ROUTE_Local_SGE_Transform @=jrt
   TargetUniverse = 9
   GridResource = "batch sge"
 @jrt

--- a/config/02-ce-sge.conf
+++ b/config/02-ce-sge.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_SGE_Transform @=jrt
+# JOB_ROUTER_ROUTE_SGE_Cluster @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch sge"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_SGE_Transform
+# JOB_ROUTER_ROUTE_NAMES = SGE_Cluster

--- a/config/02-ce-sge.conf
+++ b/config/02-ce-sge.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_SGE @=jrt
+# JOB_ROUTER_ROUTE_Local_SGE_Transform @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch sge"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_SGE
+# JOB_ROUTER_ROUTE_NAMES = Local_SGE_Transform

--- a/config/02-ce-slurm-defaults.conf
+++ b/config/02-ce-slurm-defaults.conf
@@ -17,7 +17,7 @@ JOB_ROUTER_ENTRIES @=jre
 ]
 @jre
 
-JOB_ROUTER_ROUTE_Local_Slurm @=jrt
+JOB_ROUTER_ROUTE_Local_Slurm_Transform @=jrt
   TargetUniverse = 9
   GridResource = "batch slurm"
 @jrt

--- a/config/02-ce-slurm-defaults.conf
+++ b/config/02-ce-slurm-defaults.conf
@@ -16,8 +16,3 @@ JOB_ROUTER_ENTRIES @=jre
   name = "Local_Slurm";
 ]
 @jre
-
-JOB_ROUTER_ROUTE_Local_Slurm_Transform @=jrt
-  TargetUniverse = 9
-  GridResource = "batch slurm"
-@jrt

--- a/config/02-ce-slurm.conf
+++ b/config/02-ce-slurm.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_Slurm @=jrt
+# JOB_ROUTER_ROUTE_Local_Slurm_Transform @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch slurm"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_Slurm
+# JOB_ROUTER_ROUTE_NAMES = Local_Slurm_Transform

--- a/config/02-ce-slurm.conf
+++ b/config/02-ce-slurm.conf
@@ -20,9 +20,9 @@ JOB_ROUTER_ENTRIES @=jre
 # this instead of JOB_ROUTER_ENTRIES, set "JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False"
 # in /etc/condor-ce/config.d/01-ce-router.conf and uncomment the following:
 #
-# JOB_ROUTER_ROUTE_Local_Slurm_Transform @=jrt
+# JOB_ROUTER_ROUTE_Slurm_Cluster @=jrt
 #   TargetUniverse = 9
 #   GridResource = "batch slurm"
 # @jrt
 #
-# JOB_ROUTER_ROUTE_NAMES = Local_Slurm_Transform
+# JOB_ROUTER_ROUTE_NAMES = Slurm_Cluster

--- a/docs/v5/releases.md
+++ b/docs/v5/releases.md
@@ -19,11 +19,11 @@ As such, upgrades from older versions of HTCondor-CE may require manual interven
 
 ### Support for ClassAd transforms added to the JobRouter ###
 
-!!! danger "Rename `Local_*_Transform` routes"
-    Even if you do not plan to use the new syntax, you must rename any existing routes in `JOB_ROUTER_ENTRIES` named
-    `Local_*_Transform` where `*` is the name of your batch system.
-    In other words, the route transform configurations returned by `condor_ce_config_val -dump -v JOB_ROUTER_ROUTE_`
-    should only appear in your list of used routes returned by `condor_ce_config_val JOB_ROUTER_ROUTE_NAMES` if you
+!!! danger "Transforms will override `JOB_ROUTER_ENTRIES` routes with the same name"
+    Even if you do not plan on immediately using the new syntax, it's important to note that route transforms will
+    override `JOB_ROUTER_ENTRIES` routes with the same name.
+    In other words, the route transform names returned by `condor_ce_config_val -dump -v JOB_ROUTER_ROUTE_` should only
+    appear in your list of used routes returned by `condor_ce_config_val JOB_ROUTER_ROUTE_NAMES` if you
     intend to use the new transform syntax.
 
 HTCondor-CE now includes default [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html)

--- a/docs/v5/releases.md
+++ b/docs/v5/releases.md
@@ -26,8 +26,9 @@ As such, upgrades from older versions of HTCondor-CE may require manual interven
     should only appear in your list of used routes returned by `condor_ce_config_val JOB_ROUTER_ROUTE_NAMES` if you
     intend to use the new transform syntax.
 
-HTCondor-CE now includes default [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html),
+HTCondor-CE now includes default [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html)
 equivalent to its `JOB_ROUTER_DEFAULTS`, allowing administrators to write job routes using the transform synatx.
+The old syntax continues to be the default in HTCondor-CE 5.
 Writing routes in the new syntax provides many benefits including:
 
 -   Statements being evaluated in the order they are written

--- a/docs/v5/releases.md
+++ b/docs/v5/releases.md
@@ -17,6 +17,37 @@ Updating to HTCondor-CE 5
 HTCondor-CE 5 is a major release that adds many features and overhauls the default configuration.
 As such, upgrades from older versions of HTCondor-CE may require manual intervention:
 
+### Support for ClassAd transforms added to the JobRouter ###
+
+!!! danger "Rename `Local_*_Transform` routes"
+    Even if you do not plan to use the new syntax, you must rename any existing routes in `JOB_ROUTER_ENTRIES` named
+    `Local_*_Transform` where `*` is the name of your batch system.
+    In other words, the route transform configurations returned by `condor_ce_config_val -dump -v JOB_ROUTER_ROUTE_`
+    should only appear in your list of used routes returned by `condor_ce_config_val JOB_ROUTER_ROUTE_NAMES` if you
+    intend to use the new transform syntax.
+
+HTCondor-CE now includes default [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html),
+equivalent to its `JOB_ROUTER_DEFAULTS`, allowing administrators to write job routes using the transform synatx.
+Writing routes in the new syntax provides many benefits including:
+
+-   Statements being evaluated in the order they are written
+-   Use of variables that are not included in the resultant job ad
+-   Use of simple case statements.
+
+Additionally, it is now easier to include transforms that should be evaluated before or after your routes by including
+transforms in the lists of `JOB_ROUTER_PRE_ROUTE_TRANSFORMS` and `JOB_ROUTER_PRE_ROUTE_TRANSFORMS`, respectively.
+To use the new transform syntax:
+
+1.  Disable use of `JOB_ROUTER_ENTRIES` by setting the following in `/etc/condor-ce/config.d/`:
+
+        :::console
+        JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
+
+1.  Set `JOB_ROUTER_ROUTE_<ROUTE_NAME>` to a job route in the new transform syntax where `<ROUTE_NAME>` is the name of
+    the route that you'd like to be reflected in logs and tool output.
+
+1.  Add the above `<ROUTE_NAME>` to the list of routes in `JOB_ROUTER_ROUTE_NAMES`
+
 ### No longer set `$HOME` by default ###
 
 Older versions of HTCondor-CE set `$HOME` in the routed job to the user's `$HOME` directory on the HTCondor-CE.
@@ -30,7 +61,12 @@ Full HTCondor-CE version history can be found on [GitHub](https://github.com/htc
 
 ### 5.1.0 ###
 
-[This release](https://github.com/htcondor/htcondor-ce/releases/tag/v5.1.0) includes the following bug-fixes:
+[This release](https://github.com/htcondor/htcondor-ce/releases/tag/v5.1.0) includes the following new features:
+
+-   Add support for [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html)
+    to the JobRouter ([HTCONDOR-243](https://opensciencegrid.atlassian.net/browse/HTCONDOR-243))
+
+This release also includes the following bug-fixes:
 
 -   APEL reporting scripts now use `PER_JOB_HISTORY_DIR` to collect job data. 
     ([HTCONDOR_293](https://opensciencegrid.atlassian.net/browse/HTCONDOR-293))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: HTCondor-CE Documentation
-site_url: https://htcondor.github.io/htcondor-ce-ce
+site_url: https://htcondor.github.io/htcondor-ce
 repo_url: https://github.com/htcondor/htcondor-ce/
 
 theme:


### PR DESCRIPTION
A 'JOB_ROUTER_ROUTE_' will override a route in JOB_ROUTER_ENTRIES if
they have the same name, even if
'USE_JOB_ROUTER_DEPRECATED_ROUTER_ENTRIES = True' and the
'JOB_ROUTER_ROUTE_' is uses the transform syntax.

To avoid unexpectedly overrriding an existing CE's route (many of them
probably just stick with the default names we give), use a different
name in the transform syntax.

Also add some upgrade notes about the new transform syntax, including a
warning about transform routes that we provide by default. More detailed
docs about the transform syntax to come in another commit.