### PR TITLE
Various router transform fixups (HTCONDOR-243)

### DIFF
--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -113,8 +113,8 @@ JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = True
 # Default Job Router Transforms #
 #################################
 
-JOB_ROUTER_PRE_ROUTE_TRANSFORMS = Base Cleanup OrigRequests
-JOB_ROUTER_POST_ROUTE_TRANSFORMS = Cpus Gpus Memory Queue BatchRuntime CERequirements OnExitHold
+JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = Base Cleanup OrigRequests
+JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = Cpus Gpus Memory Queue BatchRuntime CERequirements OnExitHold
 
 JOB_ROUTER_TRANSFORM_Base @=jrt
     # Job Router special values

--- a/config/01-ce-router-defaults.conf.in
+++ b/config/01-ce-router-defaults.conf.in
@@ -173,13 +173,13 @@ JOB_ROUTER_TRANSFORM_Cpus @=jrt
         if $(test_orig_RequestCpus)
             cpus = $(MY.orig_RequestCpus)
          else
-            cpus = $(default_xcount)
+            cpus = $(default_xcount:1)
          endif
     endif
 
-    EVALSET OriginalCpus           $(cpus:1)
-    EVALSET remote_SMPGranularity  $(cpus:1)
-    EVALSET remote_NodeNumber      $(cpus:1)
+    EVALSET OriginalCpus           $(cpus)
+    EVALSET remote_SMPGranularity  $(cpus)
+    EVALSET remote_NodeNumber      $(cpus)
 
     DEFAULT JobIsRunning           (JobStatus =!= 1) && (JobStatus =!= 5)
     DEFAULT JobCpus                OriginalCpus
@@ -225,12 +225,12 @@ JOB_ROUTER_TRANSFORM_Memory @=jrt
         if $(test_orig_RequestMemory)
             mem = $(MY.orig_RequestMemory)
          else
-            mem = $(default_maxMemory)
+            mem = $(default_maxMemory:2000)
          endif
     endif
 
-    EVALSET OriginalMemory         $(mem:2000)
-    EVALSET remote_OriginalMemory  $(mem:2000)
+    EVALSET OriginalMemory         $(mem)
+    EVALSET remote_OriginalMemory  $(mem)
 
     DEFAULT JobMemory              OriginalMemory
     DEFAULT RequestMemory          OriginalMemory

--- a/config/02-ce-condor-defaults.conf
+++ b/config/02-ce-condor-defaults.conf
@@ -28,7 +28,7 @@ JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618
 # To enable the UID -> HTCondor accounting group map, the admin should add this
 # line to their config:
 #
-#     JOB_ROUTER_PRE_ROUTE_TRANSFORMS = $(JOB_ROUTER_PRE_ROUTE_TRANSFORMS) UidAcctGroup
+#     JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) UidAcctGroup
 #
 # If the /etc/condor-ce/uid_acct_group.map has a mapping for this owner,
 # set the AcctGroup and AccountingGroup attributes

--- a/config/02-ce-condor.conf
+++ b/config/02-ce-condor.conf
@@ -37,11 +37,11 @@ JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618
 # line to make use of the UID to HTCondor accounting group mapfile
 # (/etc/condor-ce/uid_acct_group.map)
 #
-# JOB_ROUTER_PRE_ROUTE_TRANSFORMS = $(JOB_ROUTER_PRE_ROUTE_TRANSFORMS) UidAcctGroup
+# JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) UidAcctGroup
 
 
 # If using the new-style JobRouter configuration above, uncomment the following
 # line to make use of the X.509 to HTCondor accounting group mapfile
 # (/etc/condor-ce/x509_acct_group.map)
 #
-# JOB_ROUTER_PRE_ROUTE_TRANSFORMS = $(JOB_ROUTER_PRE_ROUTE_TRANSFORMS) x509AcctGroup
+# JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) x509AcctGroup

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -7,18 +7,18 @@ import classad
 from collections import OrderedDict
 
 JOB_ROUTER_CONFIG = r"""JOB_ROUTER_TRANSFORM_Env @=jrt
-    default_env = {advertise_pilots}
+    EVALMACRO default_env {advertise_pilots}
     if $(USE_CE_HOME_DIR)
         EVALMACRO use_ce_home userHome(Owner, "/")
         default_env = $(default_env) HOME=$(use_ce_home)
     endif
 
-    SET osg_environment {osg_environment}
+    SET osg_environment "{osg_environment}"
     EVALSET environment mergeEnvironment("$(default_env)", \
                                          osg_environment, \
                                          orig_environment, \
-                                         $(CONDORCE_PILOT_JOB_ENV), \
-                                         $(default_pilot_job_env))
+                                         "$(CONDORCE_PILOT_JOB_ENV)", \
+                                         "$(default_pilot_job_env)")
 @jrt
 
 JOB_ROUTER_POST_ROUTE_TRANSFORMS = $(JOB_ROUTER_POST_ROUTE_TRANSFORMS) Env

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -180,15 +180,6 @@ JOB_ROUTER_DEFAULTS_GENERATED @=jrd
 """
 
 ACCOUNTING_GROUP_CONFIG = """
-JOB_ROUTER_TRANSFORM_AccountingGroup @=jrt
-    # Allow admins to set their own accounting group expressions
-    # that also include the ones set in 'AccountingGroupOSG' (SOFTWARE-2067)
-    SET AccountingGroupOSG {accounting_group}
-    SET AccountingGroup    MY.AccountingGroupOSG
-@jrt
-
-JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) AccountingGroup
-
 # Also append the accounting group routing rules to the old job router syntax
 # since it's still the default syntax
 JOB_ROUTER_DEFAULTS_GENERATED @=jrd

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -21,7 +21,7 @@ JOB_ROUTER_CONFIG = r"""JOB_ROUTER_TRANSFORM_Env @=jrt
                                          "$(default_pilot_job_env)")
 @jrt
 
-JOB_ROUTER_POST_ROUTE_TRANSFORMS = $(JOB_ROUTER_POST_ROUTE_TRANSFORMS) Env
+JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES) Env
 
 JOB_ROUTER_DEFAULTS_GENERATED @=jrd
   [ MaxIdleJobs = 2000;
@@ -187,7 +187,7 @@ JOB_ROUTER_TRANSFORM_AccountingGroup @=jrt
     SET AccountingGroup    MY.AccountingGroupOSG
 @jrt
 
-JOB_ROUTER_PRE_ROUTE_TRANSFORMS = $(JOB_ROUTER_PRE_ROUTE_TRANSFORMS) AccountingGroup
+JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = $(JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES) AccountingGroup
 
 # Also append the accounting group routing rules to the old job router syntax
 # since it's still the default syntax


### PR DESCRIPTION
I haven't simplified the environment transform since the `{advertise_pilots}` string is shared between the transform and the `JOB_ROUTER_DEFAULTS`. I don't hardcode the string based on the various `DISABLE_PILOT_ADS` settings because I'd like users to be able to change that without having to restart the CE to see its effect.