### PR TITLE
(HTCONDOR-420)  Unblock all signals at condor_ce_view start-up.

### DIFF
--- a/src/condor_ce_view
+++ b/src/condor_ce_view
@@ -8,6 +8,15 @@ import socket
 import time
 import optparse
 
+# It looks like HTCondor spawns "daemon core" processes with a signal
+# mask set, probably because it doesn't want to get signals between the
+# fork() (clone()?) and exec().  These two lines of code unblock all
+# signals.  This doesn't cause this program to respond as you'd gunicorn
+# to, but they may be a problem with this script, instead.  (It would
+# have to forward signals along to the 'server' process, at the least.)
+import signal
+signal.pthread_sigmask(signal.SIG_UNBLOCK, range(1, signal.NSIG))
+
 os.environ.setdefault('CONDOR_CONFIG', '/etc/condor-ce/condor_config')
 
 import gunicorn.app.base

--- a/src/condor_ce_view
+++ b/src/condor_ce_view
@@ -11,9 +11,10 @@ import optparse
 # It looks like HTCondor spawns "daemon core" processes with a signal
 # mask set, probably because it doesn't want to get signals between the
 # fork() (clone()?) and exec().  These two lines of code unblock all
-# signals.  This doesn't cause this program to respond as you'd gunicorn
-# to, but they may be a problem with this script, instead.  (It would
-# have to forward signals along to the 'server' process, at the least.)
+# signals.  This doesn't cause this program to respond as you'd expect
+# gunicorn to, but they may be a problem with this script, instead.  (It
+# would have to forward signals along to the 'server' process, at the
+# least.)
 import signal
 signal.pthread_sigmask(signal.SIG_UNBLOCK, range(1, signal.NSIG))
 


### PR DESCRIPTION
It seems like "daemon core" daemons are expected to handle setting their own signal mask(s) on start-up.