### PR TITLE
Use consistent equals signs (HTCONDOR-418)

### DIFF
--- a/docs/v5/configuration/htcondor-routes.md
+++ b/docs/v5/configuration/htcondor-routes.md
@@ -26,7 +26,7 @@ This will catch jobs which are starting and stopping multiple times.
 
     ```hl_lines="5 8"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       # Puts the routed job on hold if the job's been idle and has been started at least
       # once or if the job has tried to start more than once
       SET Periodic_Hold ((NumJobStarts >= 1 && JobStatus == 1) || NumJobStarts > 1)
@@ -72,7 +72,7 @@ To ensure that your job lands on a Linux machine in your pool:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       SET Requirements = (TARGET.OpSys == "LINUX")
     @jrt
 

--- a/docs/v5/configuration/htcondor-routes.md
+++ b/docs/v5/configuration/htcondor-routes.md
@@ -26,7 +26,7 @@ This will catch jobs which are starting and stopping multiple times.
 
     ```hl_lines="5 8"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       # Puts the routed job on hold if the job's been idle and has been started at least
       # once or if the job has tried to start more than once
       SET Periodic_Hold ((NumJobStarts >= 1 && JobStatus == 1) || NumJobStarts > 1)
@@ -72,7 +72,7 @@ To ensure that your job lands on a Linux machine in your pool:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       SET Requirements = (TARGET.OpSys == "LINUX")
     @jrt
 

--- a/docs/v5/configuration/non-htcondor-routes.md
+++ b/docs/v5/configuration/non-htcondor-routes.md
@@ -14,7 +14,6 @@ transform and deprecated syntax, respectively:
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Slurm_Cluster @=jrt
       GridResource = "batch slurm"
-      UNIVERSE 9
       default_queue = osg_queue
     @jrt
 
@@ -27,7 +26,6 @@ transform and deprecated syntax, respectively:
     JOB_ROUTER_ENTRIES @=jre
     [
       GridResource = "batch slurm";
-      TargetUniverse = 9;
       name = "Slurm_Cluster";
       set_default_queue = "osg_queue";
     ]
@@ -73,7 +71,6 @@ attribute of the job submitted to a PBS batch system:
     ```hl_lines="4 5 6"
     JOB_ROUTER_ROUTE_Slurm_Cluster @=jrt
          GridResource = "batch slurm"
-         UNIVERSE 9
          SET Walltime = 3600
          SET AccountingGroup = x509UserProxyFirstFQAN
          SET default_CERequirements = "WallTime,AccountingGroup"
@@ -87,7 +84,6 @@ attribute of the job submitted to a PBS batch system:
     ```hl_lines="5 6 7"
     JOB_ROUTER_ENTRIES @=jre [
          GridResource = "batch slurm";
-         TargetUniverse = 9;
          name = "Slurm_Cluster";
          set_Walltime = 3600;
          set_AccountingGroup = x509UserProxyFirstFQAN;

--- a/docs/v5/configuration/non-htcondor-routes.md
+++ b/docs/v5/configuration/non-htcondor-routes.md
@@ -15,7 +15,7 @@ transform and deprecated syntax, respectively:
     JOB_ROUTER_ROUTE_Slurm_Cluster @=jrt
       GridResource = "batch slurm"
       UNIVERSE 9
-      default_queue = "osg_queue"
+      default_queue = osg_queue
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Slurm_Cluster

--- a/docs/v5/configuration/non-htcondor-routes.md
+++ b/docs/v5/configuration/non-htcondor-routes.md
@@ -14,7 +14,7 @@ transform and deprecated syntax, respectively:
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Slurm_Cluster @=jrt
       GridResource = "batch slurm"
-      TargetUniverse = 9
+      UNIVERSE 9
       default_queue = "osg_queue"
     @jrt
 
@@ -73,7 +73,7 @@ attribute of the job submitted to a PBS batch system:
     ```hl_lines="4 5 6"
     JOB_ROUTER_ROUTE_Slurm_Cluster @=jrt
          GridResource = "batch slurm"
-         TargetUniverse = 9
+         UNIVERSE 9
          SET Walltime = 3600
          SET AccountingGroup = x509UserProxyFirstFQAN
          SET default_CERequirements = "WallTime,AccountingGroup"

--- a/docs/v5/configuration/writing-job-routes.md
+++ b/docs/v5/configuration/writing-job-routes.md
@@ -81,7 +81,7 @@ To identify routes, you will need to assign a name to the route, either in the n
 
     ```hl_lines="1"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -114,7 +114,8 @@ and in the ClassAd of the routed job, which can be vieweed with
 ### Batch system
 
 Each route needs to indicate the type of batch system that jobs should be routed to.
-For HTCondor batch systems, the `UNIVERSE` command or `TargetUniverse` attribute needs to be set to `5` or `"vanilla"`.
+For HTCondor batch systems, the `UNIVERSE` command or `TargetUniverse` attribute needs to be set to `"VANILLA"` or `5`,
+respectively.
 For all other batch systems, the `GridResource` attribute needs to be set to `"batch <batch system>"`
 (where `<batch system>` can be one of `pbs`, `slurm`, `lsf`, or `sge`).
 
@@ -123,7 +124,7 @@ For all other batch systems, the `GridResource` attribute needs to be set to `"b
 
     ```hl_lines="2 6 7"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_My_Slurm @=jrt
@@ -167,12 +168,12 @@ All other jobs will be routed with `IsProduction = False`.
     ```hl_lines="1 7 12"
     JOB_ROUTER_ROUTE_Production_Jobs @=jrt
       REQUIREMENTS queue == "prod"
-      UNIVERSE 5
+      UNIVERSE VANILLA
       SET IsProduction = True
     @jrt
 
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       SET IsProduction = False
     @jrt
 
@@ -209,7 +210,7 @@ To write comments you can use `#` to comment a line:
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       # This is a comment
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -304,7 +305,7 @@ The following entry routes jobs to HTCondor if the incoming job (specified by `T
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS queue == "prod"
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -335,7 +336,7 @@ The following entry routes jobs to the HTCondor batch system if the mapped user 
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS Owner == "usatlas2"
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -363,7 +364,7 @@ The following entry routes jobs to the HTCondor batch system if the mapped user 
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS regexp("^usatlas", Owner)
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -395,7 +396,7 @@ The following entry routes jobs to the HTCondor batch system if the proxy subjec
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS regexp("\/cms\/Role\=pilot", x509UserProxyFirstFQAN)
-      UNIVERSE 5
+      UNIVERSE VANILLA
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -444,7 +445,7 @@ ClassAd transform and deprecated syntax, respectively:
 
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       # Set the requested memory to 1 GB
       default_maxMemory = 1000
     @jrt
@@ -477,7 +478,7 @@ transform and deprecated syntax, respectively:
 
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       # Set the requested memory to 1 GB
       default_xcount = 8
     @jrt
@@ -509,7 +510,7 @@ transform and deprecated syntax, respectively:
 
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       # Set the max walltime to 1 hr
       default_maxWallTime = 60
     @jrt
@@ -591,7 +592,7 @@ For example, the following HTCondor-CE configuration would result in this enviro
 
     ```hl_lines="3 4 5" 
     JOB_ROUTER_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       default_pilot_job_env = strcat("WN_SCRATCH_DIR=/nobackup",
                                      " PILOT_COLLECTOR=", JOB_COLLECTOR,
                                      " ACCOUNTING_GROUP=", toLower(JOB_VO))
@@ -683,7 +684,7 @@ on the routed job to the same value:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       COPY Environment Original_Environment
     @jrt
 
@@ -715,7 +716,7 @@ The following route removes the `Environment` attribute from the routed job:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       DELETE Environment
     @jrt
 
@@ -745,7 +746,7 @@ The following route sets the Job's `Rank` attribute to 5:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       SET Rank = 5
     @jrt
 
@@ -776,7 +777,7 @@ The following route sets the `Experiment` attribute to `atlas.osguser` if the Ow
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       EVALSET Experiment = strcat("atlas.", Owner)
     @jrt
 
@@ -817,7 +818,7 @@ set the [MaxJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_J
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Poole @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       MaxJobs = 100
     @jrt
 
@@ -847,7 +848,7 @@ set the [MaxIdleJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCond
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Poole @=jrt
-      UNIVERSE 5
+      UNIVERSE VANILLA
       MaxIdleJobs = 100
     @jrt
 

--- a/docs/v5/configuration/writing-job-routes.md
+++ b/docs/v5/configuration/writing-job-routes.md
@@ -115,8 +115,7 @@ and in the ClassAd of the routed job, which can be vieweed with
 
 Each route needs to indicate the type of batch system that jobs should be routed to.
 For HTCondor batch systems, the `UNIVERSE` command or `TargetUniverse` attribute needs to be set to `5` or `"vanilla"`.
-For all other batch systems, the `UNIVERSE` command or `TargetUniverse` attribute needs to be set to `9` or `"grid"` and
-the `GridResource` attribute needs to be set to `"batch <batch system>"`
+For all other batch systems, the `GridResource` attribute needs to be set to `"batch <batch system>"`
 (where `<batch system>` can be one of `pbs`, `slurm`, `lsf`, or `sge`).
 
 
@@ -128,7 +127,6 @@ the `GridResource` attribute needs to be set to `"batch <batch system>"`
     @jrt
 
     JOB_ROUTER_ROUTE_My_Slurm @=jrt
-      UNIVERSE 9
       GridResource = "batch slurm"
     @jrt
 
@@ -145,7 +143,6 @@ the `GridResource` attribute needs to be set to `"batch <batch system>"`
     ]
     [
       GridResource = "batch slurm";
-      TargetUniverse = 9;
       name = "My_Slurm";
     ]
     @jre

--- a/docs/v5/configuration/writing-job-routes.md
+++ b/docs/v5/configuration/writing-job-routes.md
@@ -657,7 +657,7 @@ The above operations are evaluated in order differently depending on your chosen
     subsequently remove `FOO` from the routed job:
 
         JOB_ROUTER_Condor_Pool @=jrt
-          EVALSET FOO "$(MY.Owner)"
+          EVALSET FOO = "$(MY.Owner)"
           DELETE FOO
         @jrt
 
@@ -687,7 +687,7 @@ on the routed job to the same value:
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       TargetUniverse = 5
-      COPY Environment = Original_Environment
+      COPY Environment Original_Environment
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool

--- a/docs/v5/configuration/writing-job-routes.md
+++ b/docs/v5/configuration/writing-job-routes.md
@@ -81,7 +81,7 @@ To identify routes, you will need to assign a name to the route, either in the n
 
     ```hl_lines="1"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -114,21 +114,21 @@ and in the ClassAd of the routed job, which can be vieweed with
 ### Batch system
 
 Each route needs to indicate the type of batch system that jobs should be routed to.
-For HTCondor batch systems, the `TargetUniverse` attribute needs to be set to `5` or `"vanilla"`.
-For all other batch systems, the `TargetUniverse` attribute needs to be set to `9` or `"grid"` and the `GridResource`
-attribute needs to be set to `"batch <batch system>"` (where `<batch system>` can be one of `pbs`, `slurm`, `lsf`, or
-`sge`).
+For HTCondor batch systems, the `UNIVERSE` command or `TargetUniverse` attribute needs to be set to `5` or `"vanilla"`.
+For all other batch systems, the `UNIVERSE` command or `TargetUniverse` attribute needs to be set to `9` or `"grid"` and
+the `GridResource` attribute needs to be set to `"batch <batch system>"`
+(where `<batch system>` can be one of `pbs`, `slurm`, `lsf`, or `sge`).
 
 
 === "ClassAd Transform"
 
     ```hl_lines="2 6 7"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_My_Slurm @=jrt
-      TargetUniverse = 9
+      UNIVERSE 9
       GridResource = "batch slurm"
     @jrt
 
@@ -170,12 +170,12 @@ All other jobs will be routed with `IsProduction = False`.
     ```hl_lines="1 7 12"
     JOB_ROUTER_ROUTE_Production_Jobs @=jrt
       REQUIREMENTS queue == "prod"
-      TargetUniverse = 5
+      UNIVERSE 5
       SET IsProduction = True
     @jrt
 
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       SET IsProduction = False
     @jrt
 
@@ -212,7 +212,7 @@ To write comments you can use `#` to comment a line:
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       # This is a comment
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -307,7 +307,7 @@ The following entry routes jobs to HTCondor if the incoming job (specified by `T
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS queue == "prod"
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -338,7 +338,7 @@ The following entry routes jobs to the HTCondor batch system if the mapped user 
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS Owner == "usatlas2"
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -366,7 +366,7 @@ The following entry routes jobs to the HTCondor batch system if the mapped user 
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS regexp("^usatlas", Owner)
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -398,7 +398,7 @@ The following entry routes jobs to the HTCondor batch system if the proxy subjec
     ```hl_lines="2"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
       REQUIREMENTS regexp("\/cms\/Role\=pilot", x509UserProxyFirstFQAN)
-      TargetUniverse = 5
+      UNIVERSE 5
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -447,7 +447,7 @@ ClassAd transform and deprecated syntax, respectively:
 
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       # Set the requested memory to 1 GB
       default_maxMemory = 1000
     @jrt
@@ -480,7 +480,7 @@ transform and deprecated syntax, respectively:
 
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       # Set the requested memory to 1 GB
       default_xcount = 8
     @jrt
@@ -512,7 +512,7 @@ transform and deprecated syntax, respectively:
 
     ```hl_lines="4"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       # Set the max walltime to 1 hr
       default_maxWallTime = 60
     @jrt
@@ -594,7 +594,7 @@ For example, the following HTCondor-CE configuration would result in this enviro
 
     ```hl_lines="3 4 5" 
     JOB_ROUTER_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       default_pilot_job_env = strcat("WN_SCRATCH_DIR=/nobackup",
                                      " PILOT_COLLECTOR=", JOB_COLLECTOR,
                                      " ACCOUNTING_GROUP=", toLower(JOB_VO))
@@ -686,7 +686,7 @@ on the routed job to the same value:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       COPY Environment Original_Environment
     @jrt
 
@@ -718,7 +718,7 @@ The following route removes the `Environment` attribute from the routed job:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       DELETE Environment
     @jrt
 
@@ -748,7 +748,7 @@ The following route sets the Job's `Rank` attribute to 5:
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       SET Rank = 5
     @jrt
 
@@ -779,7 +779,7 @@ The following route sets the `Experiment` attribute to `atlas.osguser` if the Ow
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Pool @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       EVALSET Experiment = strcat("atlas.", Owner)
     @jrt
 
@@ -820,7 +820,7 @@ set the [MaxJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_J
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Poole @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       MaxJobs = 100
     @jrt
 
@@ -850,7 +850,7 @@ set the [MaxIdleJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCond
 
     ```hl_lines="3"
     JOB_ROUTER_ROUTE_Condor_Poole @=jrt
-      TargetUniverse = 5
+      UNIVERSE 5
       MaxIdleJobs = 100
     @jrt
 

--- a/docs/v5/configuration/writing-job-routes.md
+++ b/docs/v5/configuration/writing-job-routes.md
@@ -542,7 +542,8 @@ HTCondor-CE offers two different methods for setting environment variables of ro
 
 - `CONDORCE_PILOT_JOB_ENV` configuration, which should be used for setting environment variables for all routed jobs to
   static strings.
-- `set_default_pilot_job_env` job route configuration, which should be used for setting environment variables:
+- `default_pilot_job_env` or `set_default_pilot_job_env` job route configuration, which should be used for setting
+  environment variables:
     - Per job route
     - To values based on incoming job attributes
     - Using [ClassAd functions](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html#predefined-functions)
@@ -585,7 +586,8 @@ For example, the following HTCondor-CE configuration would result in the followi
     ```
 
 To set environment variables per job route, based on incoming job attributes, or using ClassAd functions, add
-`set_default_pilot_job_env` to your job route configuration.
+`default_pilot_job_env` or `set_default_pilot_job_env` to your job route configuration for ClassAd transforms and
+deprecated syntax, respectively.
 For example, the following HTCondor-CE configuration would result in this environment for a job with these attributes:
 
 === "ClassAd Transform"
@@ -593,9 +595,9 @@ For example, the following HTCondor-CE configuration would result in this enviro
     ```hl_lines="3 4 5" 
     JOB_ROUTER_Condor_Pool @=jrt
       TargetUniverse = 5
-      SET default_pilot_job_env = strcat("WN_SCRATCH_DIR=/nobackup",
-                                        " PILOT_COLLECTOR=", JOB_COLLECTOR,
-                                        " ACCOUNTING_GROUP=", toLower(JOB_VO))
+      default_pilot_job_env = strcat("WN_SCRATCH_DIR=/nobackup",
+                                     " PILOT_COLLECTOR=", JOB_COLLECTOR,
+                                     " ACCOUNTING_GROUP=", toLower(JOB_VO))
     @jrt
 
     JOB_ROUTER_ROUTE_NAMES = Condor_Pool
@@ -633,8 +635,8 @@ For example, the following HTCondor-CE configuration would result in this enviro
     ```
 
 !!!tip "Debugging job route environment expressions"
-    While constructing `set_default_pilot_job_env` expressions, try wrapping your expression in
-    [debug()](#debugging-routes) to help with any issues that may arise.
+    While constructing `default_pilot_job_env` or `set_default_pilot_job_env` expressions, try wrapping your expression
+    in [debug()](#debugging-routes) to help with any issues that may arise.
     Make sure to remove `debug()` after you're done!
 
 Editing Attributes…


### PR DESCRIPTION
- Noticed a bug in our env setting via routes
- Make sure we're consistently using equals signs for `SET`, `EVALSET`, `EVALMACRO`, and job route variables
- Should we also move from `TargetUniverse` to `UNIVERSE`?