### PR TITLE
Safe defaults for APEL

### DIFF
--- a/contrib/apelscripts/condor_batch_blah.sh
+++ b/contrib/apelscripts/condor_batch_blah.sh
@@ -32,7 +32,7 @@ mkdir -p "$QUARANTINE_DIR"
 
 CONDOR_Q_EXTRA_ARGS=(-format "\n" EMPTY)
 safe_ce_config_val SCALING_ATTR APEL_SCALING_ATTR
-[[ -z $SCALING_ATTR ]] || CONDOR_Q_EXTRA_ARGS=(-format "%v|" "${SCALING_ATTR}" "${CONDOR_Q_EXTRA_ARGS[@]}")
+[[ -z $SCALING_ATTR ]] || CONDOR_Q_EXTRA_ARGS=(-format "%v|" "${SCALING_ATTR} isnt undefined ? ${SCALING_ATTR} : 1" "${CONDOR_Q_EXTRA_ARGS[@]}")
 
 safe_ce_config_val BATCH_HOST APEL_BATCH_HOST
 safe_ce_config_val CE_HOST APEL_CE_HOST

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -239,6 +239,7 @@ mv $RPM_BUILD_ROOT%{_datadir}/condor-ce/htcondor-ce-provider \
    $RPM_BUILD_ROOT%{_localstatedir}/lib/bdii/gip/provider
 mkdir -p $RPM_BUILD_ROOT%{_datadir}/condor-ce/apel/
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/condor-ce/apel/
+mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/condor/history/
 rm -f $RPM_BUILD_ROOT%{plugins_dir}/agis_json.py
 mv -f $RPM_BUILD_ROOT%{_sysconfdir}/condor-ce/config.d/05-ce-view-table.nonosg.conf \
       $RPM_BUILD_ROOT%{_sysconfdir}/condor-ce/config.d/05-ce-view-table.conf
@@ -360,6 +361,7 @@ fi
 %{_sysconfdir}/condor/config.d/50-condor-apel.conf
 %config(noreplace) %{_sysconfdir}/condor-ce/config.d/50-ce-apel.conf
 %attr(-,root,root) %dir %{_localstatedir}/lib/condor-ce/apel/
+%attr(-,condor,condor) %dir %{_localstatedir}/lib/condor/history/
 
 %{_unitdir}/condor-ce-apel.service
 %{_unitdir}/condor-ce-apel.timer


### PR DESCRIPTION
This PR adds defaults for APEL to ensure accounting does not skip jobs for a fresh installation.

* If a job's host did not define the ``APEL_SCALING_ATTR``, it is quarantined instead of reporting ``undefined`` (see https://github.com/apel/apel/issues/210)
* The default ``PER_JOB_HISTORY_DIR`` is created for user ``condor:condor`` (see #419)

The first change could alternatively set a default (as in an earlier commit). Since this may hide veritable configuration errors, excluding broken jobs and allowing manual recovery seemed preferable.