### PR TITLE
Fixed Various Manual Links (HTCondor-421)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ What is HTCondor-CE?
 --------------------
 
 HTCondor-CE is a special configuration of the HTCondor software designed as a Compute Entrypoint.
-It is configured to use the HTCondor [Job Router daemon](https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html)
+It is configured to use the HTCondor [Job Router daemon](https://htcondor.readthedocs.io/en/v9_0/grid-computing/job-router.html)
 to delegate resource allocation requests by transforming and submitting them to the site’s batch system.
 
 Benefits of running the HTCondor-CE:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ What is HTCondor-CE?
 --------------------
 
 HTCondor-CE is a special configuration of the HTCondor software designed as a Compute Entrypoint.
-It is configured to use the HTCondor [Job Router daemon](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html)
+It is configured to use the HTCondor [Job Router daemon](https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html)
 to delegate resource allocation requests by transforming and submitting them to the site’s batch system.
 
 Benefits of running the HTCondor-CE:

--- a/docs/v3/batch-system-integration.md
+++ b/docs/v3/batch-system-integration.md
@@ -1,7 +1,7 @@
 Writing Routes For HTCondor-CE
 ==============================
 
-The [JobRouter](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html) is at the heart of HTCondor-CE
+The [JobRouter](https://htcondor.readthedocs.io/en/v8_8/grid-computing/job-router.html) is at the heart of HTCondor-CE
 and allows admins to transform and direct jobs to specific batch systems.
 Customizations are made in the form of job routes where each route corresponds to a separate job transformation:
 If an incoming job matches a job route's requirements, the route creates a transformed job (referred to as the 'routed
@@ -26,7 +26,7 @@ Quirks and Pitfalls
 How Job Routes are Constructed
 ------------------------------
 
-Each job route’s [ClassAd](https://htcondor.readthedocs.io/en/stable/misc-concepts/classad-mechanism.html) is constructed by combining each entry from the `JOB_ROUTER_ENTRIES` with the `JOB_ROUTER_DEFAULTS`. Attributes that are [set_*](#setting-attributes) in `JOB_ROUTER_ENTRIES` will override those [set_*](#setting-attributes) in `JOB_ROUTER_DEFAULTS`
+Each job route’s [ClassAd](https://htcondor.readthedocs.io/en/v8_8/misc-concepts/classad-mechanism.html) is constructed by combining each entry from the `JOB_ROUTER_ENTRIES` with the `JOB_ROUTER_DEFAULTS`. Attributes that are [set_*](#setting-attributes) in `JOB_ROUTER_ENTRIES` will override those [set_*](#setting-attributes) in `JOB_ROUTER_DEFAULTS`
 
 ### JOB_ROUTER_ENTRIES
 
@@ -65,7 +65,7 @@ If the job meets the requirements of multiple routes,  the route that is chosen 
 |-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
 | < 8.7.1                           | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive. |
 | >= 8.7.1, < 8.8.7                 | **First matching route** where routes are considered in hash-table order. In this case, we recommend making each route's requirements mutually exclusive. |
-| >= 8.8.7                          | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/stable/admin-manual/configuration-macros.html#index-863) |
+| >= 8.8.7                          | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/v8_8/admin-manual/configuration-macros.html#index-863) |
 
 !!! bug "Job Route Order"
     For HTCondor versions < 8.8.7 (as well as versions >= 8.9.0 and < 8.9.5) the order of job routes does not match the
@@ -200,7 +200,7 @@ To filter jobs, use the `Requirements` attribute.
 Jobs will evaluate against the ClassAd expression set in the `Requirements` and if the expression evaluates to `TRUE`,
 the route will match.
 More information on the syntax of ClassAd's can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/stable/misc-concepts/classad-mechanism.html).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/misc-concepts/classad-mechanism.html).
 For an example on how incoming jobs interact with filtering in job routes, consult [this document](job-submission.md).
 
 When setting requirements, you need to prefix job attributes that you are filtering with `TARGET.` so that the job route
@@ -221,7 +221,7 @@ JOB_ROUTER_ENTRIES @=jre
 This is because when evaluating the route requirement, the job route will compare its own `queue` attribute to "analy"
 and see that it does not match.
 You can read more about comparing two ClassAds in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/stable/misc-concepts/classad-mechanism.html#classad-operators).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/misc-concepts/classad-mechanism.html#classad-operators).
 
 !!! note
     If you have an HTCondor batch system, note the difference with [set\_requirements](#setting-routed-job-requirements).
@@ -359,10 +359,10 @@ HTCondor-CE offers two different methods for setting environment variables of ro
 - `set_default_pilot_job_env` job route configuration, which should be used for setting environment variables:
     - Per job route
     - To values based on incoming job attributes
-    - Using [ClassAd functions](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html#predefined-functions)
+    - Using [ClassAd functions](https://htcondor.readthedocs.io/en/v8_8/misc-concepts/classad-mechanism.html#predefined-functions)
 
 Both of these methods use the new HTCondor format of the
-[environment command](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-14), which is
+[environment command](https://htcondor.readthedocs.io/en/v8_8/man-pages/condor_submit.html#index-14), which is
 described by environment variable/value pairs separated by whitespace and enclosed in double-quotes.
 For example, the following HTCondor-CE configuration would result in the following environment for all routed jobs:
 
@@ -376,7 +376,7 @@ http_proxy=proxy.wisc.edu
 ```
 
 Contents of `CONDORCE_PILOT_JOB_ENV` can reference other HTCondor-CE configuration using HTCondor's configuration
-[$() macro expansion](https://htcondor.readthedocs.io/en/stable/admin-manual/introduction-to-configuration.html#configuration-file-macros).
+[$() macro expansion](https://htcondor.readthedocs.io/en/v8_8/admin-manual/introduction-to-configuration.html#configuration-file-macros).
 For example, the following HTCondor-CE configuration would result in the following environment for all routed jobs:
 
 ``` tab="HTCondor-CE Configuration"
@@ -432,7 +432,7 @@ The following functions are operations that affect job attributes and are evalua
 
 After each job route’s ClassAd is [constructed](#how-job-routes-are-constructed), the above operations are evaluated in order. For example, if the attribute `foo` is set using `eval_set_foo` in the `JOB_ROUTER_DEFAULTS`, you'll be unable to use `delete_foo` to remove it from your jobs since the attribute is set using `eval_set_foo` after the deletion occurs according to the order of operations. To get around this, we can take advantage of the fact that operations defined in `JOB_ROUTER_DEFAULTS` get overridden by the same operation in `JOB_ROUTER_ENTRIES`. So to 'delete' `foo`, we would add `eval_set_foo = ""` to the route in the `JOB_ROUTER_ENTRIES`, resulting in `foo` being absent from the routed job.
 
-More documentation can be found in the [HTCondor manual](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html#routing-table-entry-classad-attributes).
+More documentation can be found in the [HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/grid-computing/job-router.html#routing-table-entry-classad-attributes).
 
 #### Copying attributes
 
@@ -502,11 +502,11 @@ JOB_ROUTER_ENTRIES @=jre
 This section outlines how to limit the number of total or idle jobs in a specific route (i.e., if this limit is reached, jobs will no longer be placed in this route).
 
 !!! note
-    If you are using an HTCondor batch system, limiting the number of jobs is not the preferred solution: HTCondor manages fair share on its own via [user priorities and group accounting](https://htcondor.readthedocs.io/en/stable/admin-manual/user-priorities-negotiation.html).
+    If you are using an HTCondor batch system, limiting the number of jobs is not the preferred solution: HTCondor manages fair share on its own via [user priorities and group accounting](https://htcondor.readthedocs.io/en/v8_8/admin-manual/user-priorities-negotiation.html).
 
 #### Total jobs
 
-To set a limit on the number of jobs for a specific route, set the [MaxJobs](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html#routing-table-entry-classad-attributes) attribute:
+To set a limit on the number of jobs for a specific route, set the [MaxJobs](https://htcondor.readthedocs.io/en/v8_8/grid-computing/job-router.html#routing-table-entry-classad-attributes) attribute:
 
 ```hl_lines="6 12"
 JOB_ROUTER_ENTRIES @=jre
@@ -527,7 +527,7 @@ JOB_ROUTER_ENTRIES @=jre
 
 #### Idle jobs
 
-To set a limit on the number of idle jobs for a specific route, set the [MaxIdleJobs](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html#routing-table-entry-classad-attributes) attribute:
+To set a limit on the number of idle jobs for a specific route, set the [MaxIdleJobs](https://htcondor.readthedocs.io/en/v8_8/grid-computing/job-router.html#routing-table-entry-classad-attributes) attribute:
 
 ```hl_lines="5 10"
 JOB_ROUTER_ENTRIES @=jre
@@ -595,7 +595,7 @@ JOB_ROUTER_ENTRIES @=jre
 
 ### Setting routed job requirements
 
-If you need to set requirements on your routed job, you will need to use `set_Requirements` instead of `Requirements`. The `Requirements` attribute filters jobs coming into your CE into different job routes whereas `set_Requirements` will set conditions on the routed job that must be met by the worker node it lands on. For more information on requirements, consult the [HTCondor manual](https://htcondor.readthedocs.io/en/stable/users-manual/submitting-a-job.html#about-requirements-and-rank).
+If you need to set requirements on your routed job, you will need to use `set_Requirements` instead of `Requirements`. The `Requirements` attribute filters jobs coming into your CE into different job routes whereas `set_Requirements` will set conditions on the routed job that must be met by the worker node it lands on. For more information on requirements, consult the [HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/users-manual/submitting-a-job.html#about-requirements-and-rank).
 
 To ensure that your job lands on a Linux machine in your pool:
 
@@ -688,7 +688,7 @@ Here are some example HTCondor-CE job routes:
 
 Atlas AGLT2 is using an HTCondor batch system. Here are some things to note about their routes.
 
--   Setting various HTCondor-specific attributes like `Rank`, `AccountingGroup`, `JobPrio` and `Periodic_Remove` (see the [HTCondor manual](https://htcondor.readthedocs.io/en/stable/classad-attributes/index.html) for more). Some of these are site-specific like `LastandFrac`, `IdleMP8Pressure`, `localQue`, `IsAnalyJob` and `JobMemoryLimit`.
+-   Setting various HTCondor-specific attributes like `Rank`, `AccountingGroup`, `JobPrio` and `Periodic_Remove` (see the [HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/classad-attributes/index.html) for more). Some of these are site-specific like `LastandFrac`, `IdleMP8Pressure`, `localQue`, `IsAnalyJob` and `JobMemoryLimit`.
 -   There is a difference between `Requirements` and `set_requirements`. The `Requirements` attribute matches jobs to specific routes while the `set_requirements` sets the `Requirements` attribute on the *routed* job, which confines which machines that the routed job can land on.
 
 Source: <https://www.aglt2.org/wiki/bin/view/AGLT2/CondorCE#The_JobRouter_configuration_file_content>
@@ -877,7 +877,7 @@ JOB_ROUTER_ENTRIES @=jre
 ATLAS BNL T1, they are using an HTCondor batch system. Here are some things to note about their routes:
 
 -   Setting various HTCondor-specific attributes like `JobLeaseDuration`, `Requirements` and `Periodic_Hold` (see the
-    [HTCondor manual](https://htcondor.readthedocs.io/en/stable/classad-attributes/job-classad-attributes.html)).
+    [HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/classad-attributes/job-classad-attributes.html)).
     Some of these are site-specific like `RACF_Group`, `Experiment`, `Job_Type` and `VO`.
 -   Jobs are split into different routes based on the [GlideIn](#glidein-queue) queue that they're in.
 -   There is a difference between `Requirements` and `set_requirements`.

--- a/docs/v3/installation/htcondor-ce.md
+++ b/docs/v3/installation/htcondor-ce.md
@@ -102,7 +102,7 @@ already runs such a service.
 #### Built-in mapfile ####
 
 The built-in mapfile is a
-[unified HTCondor mapfile](https://htcondor.readthedocs.io/en/stable/admin-manual/security.html#the-unified-map-file-for-authentication)
+[unified HTCondor mapfile](https://htcondor.readthedocs.io/en/v8_8/admin-manual/security.html#the-unified-map-file-for-authentication)
 located at `/etc/condor-ce/condor_mapfile`.
 This file is parsed in line-by-line order and HTCondor-CE will use the first line that matches.
 Therefore, mappings should be added to the top of the file.

--- a/docs/v3/job-submission.md
+++ b/docs/v3/job-submission.md
@@ -358,7 +358,7 @@ Here are some other HTCondor-CE documents that might be helpful:
 The following table is a reference of job attributes that can be included in HTCondor submit files and their GlobusRSL
 equivalents.
 A more comprehensive list of submit file attributes specific to HTCondor-CE can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/stable/man-pages/condor_submit.html)
+[HTCondor manual](https://htcondor.readthedocs.io/en/v8_8/man-pages/condor_submit.html)
 
 | **HTCondor Attribute** | **Globus RSL** | **Summary** |
 |------------------------------------------------------------------------------------------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/v4/batch-system-integration.md
+++ b/docs/v4/batch-system-integration.md
@@ -1,7 +1,7 @@
 Writing Routes For HTCondor-CE
 ==============================
 
-The [JobRouter](https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html) is at the heart of HTCondor-CE
+The [JobRouter](https://htcondor.readthedocs.io/v8_9_11/grid-computing/job-router.html) is at the heart of HTCondor-CE
 and allows admins to transform and direct jobs to specific batch systems.
 Customizations are made in the form of job routes where each route corresponds to a separate job transformation:
 If an incoming job matches a job route's requirements, the route creates a transformed job (referred to as the 'routed
@@ -65,7 +65,7 @@ If the job meets the requirements of multiple routes,  the route that is chosen 
 |-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
 | < 8.7.1                           | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive. |
 | >= 8.7.1, < 8.9.5                 | **First matching route** where routes are considered in hash-table order. In this case, we recommend making each route's requirements mutually exclusive. |
-| >= 8.9.5                          | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/latest/admin-manual/configuration-macros.html#JOB_ROUTER_ROUTE_NAMES) |
+| >= 8.9.5                          | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/v8_9_11/admin-manual/configuration-macros.html#JOB_ROUTER_ROUTE_NAMES) |
 
 !!! bug "Job Route Order"
     For HTCondor versions < 8.9.5 (as well as versions >= 8.7.1 and < 8.8.7) the order of job routes does not match the
@@ -200,7 +200,7 @@ To filter jobs, use the `Requirements` attribute.
 Jobs will evaluate against the ClassAd expression set in the `Requirements` and if the expression evaluates to `TRUE`,
 the route will match.
 More information on the syntax of ClassAd's can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v8_9_11/misc-concepts/classad-mechanism.html).
 For an example on how incoming jobs interact with filtering in job routes, consult [this document](remote-job-submission.md).
 
 When setting requirements, you need to prefix job attributes that you are filtering with `TARGET.` so that the job route
@@ -221,7 +221,7 @@ JOB_ROUTER_ENTRIES @=jre
 This is because when evaluating the route requirement, the job route will compare its own `queue` attribute to "analy"
 and see that it does not match.
 You can read more about comparing two ClassAds in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html#classad-operators).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v8_9_11/misc-concepts/classad-mechanism.html#classad-operators).
 
 !!! note
     If you have an HTCondor batch system, note the difference with [set\_requirements](#setting-routed-job-requirements).
@@ -359,10 +359,10 @@ HTCondor-CE offers two different methods for setting environment variables of ro
 - `set_default_pilot_job_env` job route configuration, which should be used for setting environment variables:
     - Per job route
     - To values based on incoming job attributes
-    - Using [ClassAd functions](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html#predefined-functions)
+    - Using [ClassAd functions](https://htcondor.readthedocs.io/en/v8_9_11/misc-concepts/classad-mechanism.html#predefined-functions)
 
 Both of these methods use the new HTCondor format of the
-[environment command](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-14), which is
+[environment command](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-14), which is
 described by environment variable/value pairs separated by whitespace and enclosed in double-quotes.
 For example, the following HTCondor-CE configuration would result in the following environment for all routed jobs:
 
@@ -380,7 +380,7 @@ For example, the following HTCondor-CE configuration would result in the followi
     ```
 
 Contents of `CONDORCE_PILOT_JOB_ENV` can reference other HTCondor-CE configuration using HTCondor's configuration
-[$() macro expansion](https://htcondor.readthedocs.io/en/stable/admin-manual/introduction-to-configuration.html#configuration-file-macros).
+[$() macro expansion](https://htcondor.readthedocs.io/en/v8_9_11/admin-manual/introduction-to-configuration.html#configuration-file-macros).
 For example, the following HTCondor-CE configuration would result in the following environment for all routed jobs:
 
 === "HTCondor-CE Configuration"
@@ -897,7 +897,7 @@ JOB_ROUTER_ENTRIES @=jre
 ATLAS BNL T1, they are using an HTCondor batch system. Here are some things to note about their routes:
 
 -   Setting various HTCondor-specific attributes like `JobLeaseDuration`, `Requirements` and `Periodic_Hold` (see the
-    [HTCondor manual](https://htcondor.readthedocs.io/en/stable/classad-attributes/job-classad-attributes.html)).
+    [HTCondor manual](https://htcondor.readthedocs.io/en/v8_9_11/classad-attributes/job-classad-attributes.html)).
     Some of these are site-specific like `RACF_Group`, `Experiment`, `Job_Type` and `VO`.
 -   Jobs are split into different routes based on the [GlideIn](#glidein-queue) queue that they're in.
 -   There is a difference between `Requirements` and `set_requirements`.

--- a/docs/v4/batch-system-integration.md
+++ b/docs/v4/batch-system-integration.md
@@ -1,7 +1,7 @@
 Writing Routes For HTCondor-CE
 ==============================
 
-The [JobRouter](https://htcondor.readthedocs.io/v8_9_11/grid-computing/job-router.html) is at the heart of HTCondor-CE
+The [JobRouter](https://htcondor.readthedocs.io/en/v8_9_11/grid-computing/job-router.html) is at the heart of HTCondor-CE
 and allows admins to transform and direct jobs to specific batch systems.
 Customizations are made in the form of job routes where each route corresponds to a separate job transformation:
 If an incoming job matches a job route's requirements, the route creates a transformed job (referred to as the 'routed

--- a/docs/v4/installation/central-collector.md
+++ b/docs/v4/installation/central-collector.md
@@ -4,10 +4,10 @@ Installing an HTCondor-CE Central Collector
 The HTCondor-CE Central Collector is an information service designed to provide a an overview and descriptions of grid
 services.
 Based on the
-[HTCondorView Server](https://htcondor.readthedocs.io/en/latest/admin-manual/setting-up-special-environments.html#configuring-the-htcondorview-server),
-the Central Collector accepts [ClassAds](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html)
+[HTCondorView Server](https://htcondor.readthedocs.io/en/v8_9_11/admin-manual/setting-up-special-environments.html#configuring-the-htcondorview-server),
+the Central Collector accepts [ClassAds](https://htcondor.readthedocs.io/en/v8_9_11/misc-concepts/classad-mechanism.html)
 from site HTCondor-CEs by default but may accept from other services using the
-[HTCondor Python Bindings](https://htcondor.readthedocs.io/en/latest/apis/python-bindings/index.html).
+[HTCondor Python Bindings](https://htcondor.readthedocs.io/en/v8_9_11/apis/python-bindings/index.html).
 By distributing configuration to each member site, a central grid team can coordinate the information that site 
 HTCondor-CEs should advertise.
 

--- a/docs/v4/installation/htcondor-ce.md
+++ b/docs/v4/installation/htcondor-ce.md
@@ -4,9 +4,9 @@ Installing HTCondor-CE 4
 !!! warning "Update to HTCondor-CE 5"
     In the [HTCondor Yum repositories](http://research.cs.wisc.edu/htcondor/instructions/), HTCondor-CE 4 is distributed
     alongside the HTCondor 8.9
-    [development release series](https://htcondor.readthedocs.io/en/latest/version-history/introduction-version-history.html#the-stable-release-series),
+    [development release series](https://htcondor.readthedocs.io/en/v8_9_11/version-history/introduction-version-history.html#the-stable-release-series),
     which has been turned into the HTCondor 9.0
-    [stable release series](https://htcondor.readthedocs.io/en/latest/version-history/introduction-version-history.html#the-stable-release-series).
+    [stable release series](https://htcondor.readthedocs.io/en/v8_9_11/version-history/introduction-version-history.html#the-stable-release-series).
     Security and other bug-fixes that would have been targeted for 8.9 will now only be available in 9.0 or 8.8.
     Consider [updating to HTCondor-CE 5](../../v5/releases.md#updating-to-htcondor-ce-5) and HTCondor 9.0 at your
     earliest convenience.

--- a/docs/v4/installation/htcondor-ce.md
+++ b/docs/v4/installation/htcondor-ce.md
@@ -17,7 +17,7 @@ Installing HTCondor-CE 4
 
 HTCondor-CE is a special configuration of the HTCondor software designed as a Compute Entrypoint solution for computing
 grids (e.g. [European Grid Infrastructure](https://www.egi.eu/), [Open Science Grid](https://opensciencegrid.org/)).
-It is configured to use the [Job Router daemon](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html)
+It is configured to use the [Job Router daemon](https://htcondor.readthedocs.io/en/v8_9_11/grid-computing/job-router.html)
 to delegate resource allocation requests by transforming and submitting them to the site’s batch system.
 See the [home page](../../index.md) for more details on the features and architecture of HTCondor-CE.
 
@@ -108,7 +108,7 @@ Additionally, the HTCondor-CE service uses [X.509 certificates](#configuring-cer
 #### Built-in mapfile ####
 
 The built-in mapfile is a
-[unified HTCondor mapfile](https://htcondor.readthedocs.io/en/stable/admin-manual/security.html#the-unified-map-file-for-authentication)
+[unified HTCondor mapfile](https://htcondor.readthedocs.io/en/v8_9_11/admin-manual/security.html#the-unified-map-file-for-authentication)
 located at `/etc/condor-ce/condor_mapfile`.
 This file is parsed in line-by-line order and HTCondor-CE will use the first line that matches.
 Therefore, mappings should be added to the top of the file.

--- a/docs/v4/releases.md
+++ b/docs/v4/releases.md
@@ -143,7 +143,7 @@ HTCondor batch systems ([#245](https://github.com/htcondor/htcondor-ce/issues/24
         ENABLE_JOB_RETRIES = True
 
 - **Simplified daemon authentication:** HTCondor-CE now uses
-  [FS authentication](https://htcondor.readthedocs.io/en/stable/admin-manual/security.html#file-system-authentication)
+  [FS authentication](https://htcondor.readthedocs.io/en/v8_9_11/admin-manual/security.html#file-system-authentication)
   between its own daemons instead of GSI.
 - **Simplified remote CE requirements format:**
   [Remote CE requirements](batch-system-integration.md#setting-batch-system-directives)

--- a/docs/v4/remote-job-submission.md
+++ b/docs/v4/remote-job-submission.md
@@ -93,7 +93,7 @@ you can use standard HTCondor submission tools.
 
 To submit jobs to a remote HTCondor-CE (or any other externally facing HTCondor SchedD) from an HTCondor submit host,
 you need to construct an HTCondor submit file describing an
-[HTCondor-C job](https://htcondor.readthedocs.io/en/latest/grid-computing/grid-universe.html#htcondor-c-the-condor-grid-type):
+[HTCondor-C job](https://htcondor.readthedocs.io/en/v8_9_11/grid-computing/grid-universe.html#htcondor-c-the-condor-grid-type):
 
 1.  Write a submit file, `ce_test.sub`:
 
@@ -206,23 +206,23 @@ Submit File Commands
 The following table is a reference of commands that are commonly included in HTCondor submit files used for HTCondor-CE
 resource allocation requests.
 A more comprehensive list of submit file commands specific to HTCondor can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html).
 
 !!!tip "HTCondor string values"
     If you are setting an attribute to a string value, make sure enclose the string in double-quotes (`"`)
 
 | **Command**                                                                                                 | **Description**                                                                                                                                                                              |
 |-------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [arguments](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-13)                | Arguments that will be provided to the executable for the resource allocation request.                                                                                                       |
-| [error](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-18)                    | Path to the file on the client host that stores stderr from the resource allocation request.                                                                                                 |
-| [executable](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-19)               | Path to the file on the client host that the resource allocation request will execute.                                                                                                       |
-| [input](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-23)                    | Path to the file on the client host that stores input to be piped into the stdin of the resource allocation request.                                                                         |
+| [arguments](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-13)                | Arguments that will be provided to the executable for the resource allocation request.                                                                                                       |
+| [error](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-18)                    | Path to the file on the client host that stores stderr from the resource allocation request.                                                                                                 |
+| [executable](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-19)               | Path to the file on the client host that the resource allocation request will execute.                                                                                                       |
+| [input](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-23)                    | Path to the file on the client host that stores input to be piped into the stdin of the resource allocation request.                                                                         |
 | +maxMemory                                                                                                  | The amount of memory in MB that you wish to allocate to the resource allocation request.                                                                                                     |
 | +maxWallTime                                                                                                | The maximum walltime (in minutes) the resource allocation request is allowed to run before it is removed.                                                                                    |
-| [output](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-37)                   | Path to the file on the client host that stores stdout from the resource allocation request.                                                                                                 |
+| [output](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-37)                   | Path to the file on the client host that stores stdout from the resource allocation request.                                                                                                 |
 | +remote\_queue                                                                                              | Assign resource allocation request to the target queue in the scheduler.                                                                                                                     |
-| [transfer\_input\_files](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-110)  | A comma-delimited list of all the files and directories to be transferred into the working directory for the resource allocation request, before the resource allocation request is started. |
-| [transfer\_output\_files](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-113) | A comma-delimited list of all the files and directories to be transferred back to the client, after the resource allocation request completes.                                               |
+| [transfer\_input\_files](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-110)  | A comma-delimited list of all the files and directories to be transferred into the working directory for the resource allocation request, before the resource allocation request is started. |
+| [transfer\_output\_files](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_submit.html#index-113) | A comma-delimited list of all the files and directories to be transferred back to the client, after the resource allocation request completes.                                               |
 | +WantWholeNode                                                                                              | When set to `True`, request entire node for the resource allocation request (HTCondor batch systems only)                                                                                    |
 | +xcount                                                                                                     | The number of cores to allocate for the resource allocation request.                                                                                                                         |
 

--- a/docs/v4/troubleshooting/remote-troubleshooting.md
+++ b/docs/v4/troubleshooting/remote-troubleshooting.md
@@ -78,7 +78,7 @@ Once you've verified network connectivity, you can start verifying the HTCondor-
 ### Inspecting daemons ###
 
 To inspect the running daemons of a remote HTCondor-CE,
-use [condor_status](https://htcondor.readthedocs.io/en/latest/man-pages/condor_status.html):
+use [condor_status](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_status.html):
 
 ```console
 $ condor_status -any -pool htcondor-ce.chtc.wisc.edu:9619
@@ -117,7 +117,7 @@ CurrentJobsRunningJava = 0
 ### Inspecting resource requests ###
 
 To inspect resource requests submitted to a remote HTCondor-CE,
-use [condor_q](https://htcondor.readthedocs.io/en/latest/man-pages/condor_q.html):
+use [condor_q](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_q.html):
 
 ```console
 $ condor_q -all -name htcondor-ce.chtc.wisc.edu -pool htcondor-ce.chtc.wisc.edu:9619
@@ -151,7 +151,7 @@ CommittedTime = 0
 ### Retrieving HTCondor-CE configuration ###
 
 To verify a remote HTCondor-CE configuration,
-use [condor_config_val](https://htcondor.readthedocs.io/en/latest/man-pages/condor_config_val.html):
+use [condor_config_val](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_config_val.html):
 
 ```console
 $ condor_config_val -name htcondor-ce.chtc.wisc.edu -pool htcondor-ce.chtc.wisc.edu:9619 -dump
@@ -199,7 +199,7 @@ timeleft  : 3:55:22
 ```
 
 After you have retrieved your credential, verify that you have the ability to submit requests to the remote HTCondor-CE
-(i.e., `WRITE` access) with [condor_ping](https://htcondor.readthedocs.io/en/latest/man-pages/condor_ping.html):
+(i.e., `WRITE` access) with [condor_ping](https://htcondor.readthedocs.io/en/v8_9_11/man-pages/condor_ping.html):
 
 ```console
 $ export _condor_SEC_CLIENT_AUTHENTICATION_METHODS=SCITOKENS,GSI

--- a/docs/v5/configuration/htcondor-routes.md
+++ b/docs/v5/configuration/htcondor-routes.md
@@ -64,7 +64,7 @@ instead of `Requirements` for ClassAd transform and deprecated syntaxes, respect
 The `Requirements` attribute filters jobs coming into your CE into different job routes whereas the set function will
 set conditions on the routed job that must be met by the worker node it lands on.
 For more information on requirements, consult the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#about-requirements-and-rank).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v9_0/users-manual/submitting-a-job.html#about-requirements-and-rank).
 
 To ensure that your job lands on a Linux machine in your pool:
 

--- a/docs/v5/configuration/job-router-overview.md
+++ b/docs/v5/configuration/job-router-overview.md
@@ -1,7 +1,7 @@
 Job Router Configuration Overview
 =================================
 
-The [HTCondor Job Router](https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html) is at the heart of
+The [HTCondor Job Router](https://htcondor.readthedocs.io/en/v9_0/grid-computing/job-router.html) is at the heart of
 HTCondor-CE and allows admins to transform and direct jobs to specific batch systems.
 Customizations are made in the form of job routes where each route corresponds to a separate job transformation:
 If an incoming job matches a job route's requirements, the route creates a transformed job (referred to as the 'routed
@@ -26,7 +26,7 @@ to the new syntax as [outlined below](#choosing-a-syntax).
 
 ### ClassAd transforms ###
 
-The HTCondor [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html) were
+The HTCondor [ClassAd transforms](https://htcondor.readthedocs.io/en/v9_0/misc-concepts/transforms.html) were
 originally introduced to HTCondor to perform in-place transformations of user jobs submitted to an HTCondor pool.
 In the HTCondor 8.9 series, the Job Router was updated to support transforms and HTCondor-CE 5 adds the configuration
 necessary to support routes written as ClassAd transforms.
@@ -41,7 +41,7 @@ in the following order:
 ### Deprecated syntax ###
 
 Since the inception of HTCondor-CE, job routes have been written as a
-[list of ClassAds](https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#deprecated-router-configuration).
+[list of ClassAds](https://htcondor.readthedocs.io/en/v9_0/grid-computing/job-router.html#deprecated-router-configuration).
 Each job route’s [ClassAd](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html) is constructed
 by combining each entry from the `JOB_ROUTER_ENTRIES` with the `JOB_ROUTER_DEFAULTS`:
 

--- a/docs/v5/configuration/writing-job-routes.md
+++ b/docs/v5/configuration/writing-job-routes.md
@@ -283,7 +283,7 @@ syntaxes, respectively.
 Incoming jobs will be evaluated against the ClassAd expression set in the route's requirements and if the expression
 evaluates to `TRUE`, the route will match.
 More information on the syntax of ClassAd's can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v9_0/misc-concepts/classad-mechanism.html).
 For an example on how incoming jobs interact with filtering in job routes, consult
 [this document](../remote-job-submission.md).
 
@@ -544,10 +544,10 @@ HTCondor-CE offers two different methods for setting environment variables of ro
   environment variables:
     - Per job route
     - To values based on incoming job attributes
-    - Using [ClassAd functions](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html#predefined-functions)
+    - Using [ClassAd functions](https://htcondor.readthedocs.io/en/v9_0/misc-concepts/classad-mechanism.html#predefined-functions)
 
 Both of these methods use the new HTCondor format of the
-[environment command](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-14), which is
+[environment command](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-14), which is
 described by environment variable/value pairs separated by whitespace and enclosed in double-quotes.
 For example, the following HTCondor-CE configuration would result in the following environment for all routed jobs:
 
@@ -566,7 +566,7 @@ For example, the following HTCondor-CE configuration would result in the followi
     ```
 
 Contents of `CONDORCE_PILOT_JOB_ENV` can reference other HTCondor-CE configuration using HTCondor's configuration
-[$() macro expansion](https://htcondor.readthedocs.io/en/stable/admin-manual/introduction-to-configuration.html#configuration-file-macros).
+[$() macro expansion](https://htcondor.readthedocs.io/en/v9_0/admin-manual/introduction-to-configuration.html#configuration-file-macros).
 For example, the following HTCondor-CE configuration would result in the following environment for all routed jobs:
 
 === "HTCondor-CE Configuration"
@@ -670,7 +670,7 @@ The above operations are evaluated in order differently depending on your chosen
     being set to the empty string in the routed job.
 
 More documentation can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#routing-table-entry-commands-and-macro-values)
+[HTCondor manual](https://htcondor.readthedocs.io/en/v9_0/grid-computing/job-router.html#routing-table-entry-commands-and-macro-values)
 
 ### Copying attributes
 

--- a/docs/v5/installation/central-collector.md
+++ b/docs/v5/installation/central-collector.md
@@ -4,10 +4,10 @@ Installing an HTCondor-CE Central Collector
 The HTCondor-CE Central Collector is an information service designed to provide a an overview and descriptions of grid
 services.
 Based on the
-[HTCondorView Server](https://htcondor.readthedocs.io/en/latest/admin-manual/setting-up-special-environments.html#configuring-the-htcondorview-server),
-the Central Collector accepts [ClassAds](https://htcondor.readthedocs.io/en/latest/misc-concepts/classad-mechanism.html)
+[HTCondorView Server](https://htcondor.readthedocs.io/en/v9_0/admin-manual/setting-up-special-environments.html#configuring-the-htcondorview-server),
+the Central Collector accepts [ClassAds](https://htcondor.readthedocs.io/en/v9_0/misc-concepts/classad-mechanism.html)
 from site HTCondor-CEs by default but may accept from other services using the
-[HTCondor Python Bindings](https://htcondor.readthedocs.io/en/latest/apis/python-bindings/index.html).
+[HTCondor Python Bindings](https://htcondor.readthedocs.io/en/v9_0/apis/python-bindings/index.html).
 By distributing configuration to each member site, a central grid team can coordinate the information that site 
 HTCondor-CEs should advertise.
 

--- a/docs/v5/installation/htcondor-ce.md
+++ b/docs/v5/installation/htcondor-ce.md
@@ -7,7 +7,7 @@ Installing HTCondor-CE 5
 
 HTCondor-CE is a special configuration of the HTCondor software designed as a Compute Entrypoint solution for computing
 grids (e.g. [European Grid Infrastructure](https://www.egi.eu/), [Open Science Grid](https://opensciencegrid.org/)).
-It is configured to use the [Job Router daemon](https://htcondor.readthedocs.io/en/stable/grid-computing/job-router.html)
+It is configured to use the [Job Router daemon](https://htcondor.readthedocs.io/en/v9_0/grid-computing/job-router.html)
 to delegate resource allocation requests by transforming and submitting them to the site’s batch system.
 See the [home page](../../index.md) for more details on the features and architecture of HTCondor-CE.
 

--- a/docs/v5/releases.md
+++ b/docs/v5/releases.md
@@ -34,7 +34,7 @@ As such, upgrades from older versions of HTCondor-CE may require manual interven
     appear in your list of used routes returned by `condor_ce_config_val JOB_ROUTER_ROUTE_NAMES` if you
     intend to use the new transform syntax.
 
-HTCondor-CE now includes default [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html)
+HTCondor-CE now includes default [ClassAd transforms](https://htcondor.readthedocs.io/en/v9_0/misc-concepts/transforms.html)
 equivalent to its `JOB_ROUTER_DEFAULTS`, allowing administrators to write job routes using the transform synatx.
 The old syntax continues to be the default in HTCondor-CE 5.
 Writing routes in the new syntax provides many benefits including:
@@ -60,7 +60,7 @@ respectively.  To use the new transform syntax:
 ### New `condor_mapfile` format and locations  ###
 
 HTCondor-CE 5 separates its
-[unified mapfile](https://htcondor.readthedocs.io/en/stable/admin-manual/security.html#the-unified-map-file-for-authentication)
+[unified mapfile](https://htcondor.readthedocs.io/en/v9_0/admin-manual/security.html#the-unified-map-file-for-authentication)
 used for authentication between multiple files across multiple directories.
 Additionally, any regular expressions in the second field must be enclosed by `/`.
 To update your mappings to the new format and location, perform the following actions:
@@ -128,7 +128,7 @@ Full HTCondor-CE version history can be found on [GitHub](https://github.com/htc
 
 [This release](https://github.com/htcondor/htcondor-ce/releases/tag/v5.1.0) includes the following new features:
 
--   Add support for [ClassAd transforms](https://htcondor.readthedocs.io/en/latest/misc-concepts/transforms.html)
+-   Add support for [ClassAd transforms](https://htcondor.readthedocs.io/en/v9_0/misc-concepts/transforms.html)
     to the JobRouter ([HTCONDOR-243](https://opensciencegrid.atlassian.net/browse/HTCONDOR-243))
 -   Add mapped user and X.509 attribute to local HTCondor pool AccountingGroup mappings to Job Routers configured to use
     the ClassAd transform syntax ([HTCONDOR-187](https://opensciencegrid.atlassian.net/browse/HTCONDOR-187))

--- a/docs/v5/remote-job-submission.md
+++ b/docs/v5/remote-job-submission.md
@@ -93,7 +93,7 @@ you can use standard HTCondor submission tools.
 
 To submit jobs to a remote HTCondor-CE (or any other externally facing HTCondor SchedD) from an HTCondor submit host,
 you need to construct an HTCondor submit file describing an
-[HTCondor-C job](https://htcondor.readthedocs.io/en/latest/grid-computing/grid-universe.html#htcondor-c-the-condor-grid-type):
+[HTCondor-C job](https://htcondor.readthedocs.io/en/v9_0/grid-computing/grid-universe.html#htcondor-c-the-condor-grid-type):
 
 1.  Write a submit file, `ce_test.sub`:
 
@@ -206,23 +206,23 @@ Submit File Commands
 The following table is a reference of commands that are commonly included in HTCondor submit files used for HTCondor-CE
 resource allocation requests.
 A more comprehensive list of submit file commands specific to HTCondor can be found in the
-[HTCondor manual](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html).
+[HTCondor manual](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html).
 
 !!!tip "HTCondor string values"
     If you are setting an attribute to a string value, make sure enclose the string in double-quotes (`"`)
 
 | **Command**                                                                                                 | **Description**                                                                                                                                                                              |
 |-------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [arguments](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-13)                | Arguments that will be provided to the executable for the resource allocation request.                                                                                                       |
-| [error](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-18)                    | Path to the file on the client host that stores stderr from the resource allocation request.                                                                                                 |
-| [executable](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-19)               | Path to the file on the client host that the resource allocation request will execute.                                                                                                       |
-| [input](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-23)                    | Path to the file on the client host that stores input to be piped into the stdin of the resource allocation request.                                                                         |
+| [arguments](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-13)                | Arguments that will be provided to the executable for the resource allocation request.                                                                                                       |
+| [error](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-18)                    | Path to the file on the client host that stores stderr from the resource allocation request.                                                                                                 |
+| [executable](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-19)               | Path to the file on the client host that the resource allocation request will execute.                                                                                                       |
+| [input](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-23)                    | Path to the file on the client host that stores input to be piped into the stdin of the resource allocation request.                                                                         |
 | +maxMemory                                                                                                  | The amount of memory in MB that you wish to allocate to the resource allocation request.                                                                                                     |
 | +maxWallTime                                                                                                | The maximum walltime (in minutes) the resource allocation request is allowed to run before it is removed.                                                                                    |
-| [output](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-37)                   | Path to the file on the client host that stores stdout from the resource allocation request.                                                                                                 |
+| [output](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-37)                   | Path to the file on the client host that stores stdout from the resource allocation request.                                                                                                 |
 | +remote\_queue                                                                                              | Assign resource allocation request to the target queue in the scheduler.                                                                                                                     |
-| [transfer\_input\_files](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-110)  | A comma-delimited list of all the files and directories to be transferred into the working directory for the resource allocation request, before the resource allocation request is started. |
-| [transfer\_output\_files](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html#index-113) | A comma-delimited list of all the files and directories to be transferred back to the client, after the resource allocation request completes.                                               |
+| [transfer\_input\_files](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-110)  | A comma-delimited list of all the files and directories to be transferred into the working directory for the resource allocation request, before the resource allocation request is started. |
+| [transfer\_output\_files](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_submit.html#index-113) | A comma-delimited list of all the files and directories to be transferred back to the client, after the resource allocation request completes.                                               |
 | +WantWholeNode                                                                                              | When set to `True`, request entire node for the resource allocation request (HTCondor batch systems only)                                                                                    |
 | +xcount                                                                                                     | The number of cores to allocate for the resource allocation request.                                                                                                                         |
 

--- a/docs/v5/troubleshooting/remote-troubleshooting.md
+++ b/docs/v5/troubleshooting/remote-troubleshooting.md
@@ -78,7 +78,7 @@ Once you've verified network connectivity, you can start verifying the HTCondor-
 ### Inspecting daemons ###
 
 To inspect the running daemons of a remote HTCondor-CE,
-use [condor_status](https://htcondor.readthedocs.io/en/latest/man-pages/condor_status.html):
+use [condor_status](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_status.html):
 
 ```console
 $ condor_status -any -pool htcondor-ce.chtc.wisc.edu:9619
@@ -117,7 +117,7 @@ CurrentJobsRunningJava = 0
 ### Inspecting resource requests ###
 
 To inspect resource requests submitted to a remote HTCondor-CE,
-use [condor_q](https://htcondor.readthedocs.io/en/latest/man-pages/condor_q.html):
+use [condor_q](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_q.html):
 
 ```console
 $ condor_q -all -name htcondor-ce.chtc.wisc.edu -pool htcondor-ce.chtc.wisc.edu:9619
@@ -151,7 +151,7 @@ CommittedTime = 0
 ### Retrieving HTCondor-CE configuration ###
 
 To verify a remote HTCondor-CE configuration,
-use [condor_config_val](https://htcondor.readthedocs.io/en/latest/man-pages/condor_config_val.html):
+use [condor_config_val](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_config_val.html):
 
 ```console
 $ condor_config_val -name htcondor-ce.chtc.wisc.edu -pool htcondor-ce.chtc.wisc.edu:9619 -dump
@@ -199,7 +199,7 @@ timeleft  : 3:55:22
 ```
 
 After you have retrieved your credential, verify that you have the ability to submit requests to the remote HTCondor-CE
-(i.e., `WRITE` access) with [condor_ping](https://htcondor.readthedocs.io/en/latest/man-pages/condor_ping.html):
+(i.e., `WRITE` access) with [condor_ping](https://htcondor.readthedocs.io/en/v9_0/man-pages/condor_ping.html):
 
 ```console
 $ export _condor_SEC_CLIENT_AUTHENTICATION_METHODS=SCITOKENS,GSI


### PR DESCRIPTION
Changed the doc links in v3, v4, and v5 to refer to HTCondor Manuals 8.8, 8.9.11, and 9.0 respectively. 