### PR TITLE
Add upgrade section about SSL cert locations

### DIFF
--- a/docs/v5/configuration/authentication.md
+++ b/docs/v5/configuration/authentication.md
@@ -18,9 +18,12 @@ HTCondor-CE uses
 stored in `/etc/condor-ce/mapfiles.d/*.conf` to map incoming jobs with credentials to local Unix accounts.
 These files are parsed in lexicographic order and HTCondor-CE will use the first line that matches for the
 authentication method that the client and your HTCondor-CE negotiates.
+Each mapfile line consists of three fields:
 
-!!! tip "Rich mappings with regular expressions"
-    Mapfiles can be written using Perl Compatible Regular Expressions (PCRE) if enclosed by `/`.
+1.  HTCondor authentication method
+1.  Incoming credential principal formatted as a Perl Compatible Regular Expression (PCRE)
+1.  Local account
+
 
 ### SciTokens ###
 
@@ -52,7 +55,7 @@ incoming certificate and the unix account under which the job should run, respec
 VOMS attributes of incoming X.509 proxy certificates can also be used for mapping:
 
 ```
-GSI "<DISTINGUISHED NAME>,<VOMS FQAN 1>,<VOMS FQAN 2>,...,<VOMSFQAN N>" <USERNAME>
+GSI /<DISTINGUISHED NAME>,<VOMS FQAN 1>,<VOMS FQAN 2>,...,<VOMSFQAN N>/ <USERNAME>
 ```
 
 Replacing `<DISTINGUISHED NAME>` (escaping any `/` with `\/`), `<VOMSFQAN>` fields, and `<USERNAME>` with the

--- a/docs/v5/configuration/authentication.md
+++ b/docs/v5/configuration/authentication.md
@@ -24,6 +24,8 @@ Each mapfile line consists of three fields:
 1.  Incoming credential principal formatted as a Perl Compatible Regular Expression (PCRE)
 1.  Local account
 
+!!! tip "Applying mapping changes"
+    When changing your HTCondor-CE mappings, run `condor_ce_reconfig` to apply your changes.
 
 ### SciTokens ###
 

--- a/docs/v5/releases.md
+++ b/docs/v5/releases.md
@@ -103,6 +103,15 @@ To update your mappings to the new format and location, perform the following ac
 
             SCITOKENS /^https:\/\/scitokens.org\/osg-connect,.*/ osg
 
+### Specify certificate locations for token authentication ###
+
+HTCondor-CE 5 adds improved support for accepting pilot jobs submitted with bearer tokens
+(e.g., SciTokens or WLCG tokens).
+As part of the bearer token authentication, HTCondor-CE uses its host certificate to perform an SSL handshake with the
+client to establish trust with its token issuer.
+Consult the [authentication documentation](configuration/authentication.md#configuring-certificates) to configure
+certificate locations for token authentication.
+
 ### No longer set `$HOME` by default ###
 
 Older versions of HTCondor-CE set `$HOME` in the routed job to the user's `$HOME` directory on the HTCondor-CE.


### PR DESCRIPTION
The default `AUTH_SSL_*` config knobs lead to confusing token
authentication failures for folks that are used to grid cert/CA
locations