### PR TITLE
HTCONDOR-662 Fix post-route for CPUs and Memory

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -137,7 +137,6 @@ JOB_ROUTER_TRANSFORM_Cleanup @=jrt
 
 JOB_ROUTER_TRANSFORM_OrigRequests @=jrt
     # Copy original, incoming job attributes for use in post transforms
-    COPY /^Request.+$/             orig_\0
     COPY /^OnExitHold.*$/          orig_\0
     COPY BatchRuntime              orig_BatchRuntime
     COPY environment               orig_environment
@@ -151,39 +150,40 @@ JOB_ROUTER_TRANSFORM_OrigRequests @=jrt
 JOB_ROUTER_TRANSFORM_Cpus @=jrt
     # Outside of the HTCondor WholeNodeJobs case, set RequestCpus to one of the following, in order:
     # 1. 'xcount' from the source job
-    # 2. RequestCpus from the source job
+    # 2. RequestCpus from the source job, but only if > 1
     # 3. default_xcount from the job route
     # 4. 1
+
+    if defined MY.xcount
+        EVALSET RequestCpus xcount
+    else
+        EVALMACRO test_RequestCpus ($(MY.RequestCpus:0)) > 1
+        if $(test_RequestCpus)
+            # RequestCpus already correct
+        else
+            EVALSET RequestCpus $(default_xcount:1)
+        endif
+    endif
+
+    # the old-style transforms ignored RequestCPUs for... reasons? when setting these. we do the same here.
+    EVALSET remote_SMPGranularity  xcount ?: ($(default_xcount:1))
+    COPY    remote_SMPGranularity  remote_NodeNumber
+
+    SET JobIsRunning           (JobStatus =!= 1) && (JobStatus =!= 5)
+
     if $(test_want_whole_node)
-        SET JOB_GLIDEIN_Cpus       "$$(MY.TotalCpus ?: JobCpus)"
+        SET JOB_GLIDEIN_Cpus       "$$([MY.TotalCpus ?: JobCpus])"
         # MATCH_EXP_JOB_GLIDEIN_Cpus is based on the value of JOB_GLIDEIN_Cpus once the routed job is matched to an
         # HTCondor slot
         SET GlideinCpusIsGood      int(MATCH_EXP_JOB_GLIDEIN_Cpus ?: "0") isnt error
         # Also used by JobGpus and JobMemory
-        SET JobIsRunning           (JobStatus =!= 1) && (JobStatus =!= 5) && GlideinCpusIsGood
+        SET JobIsRunning           $(MY.JobIsRunning) && GlideinCpusIsGood
+        COPY RequestCpus           OriginalCpus
         SET JobCpus                JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Cpus) : OriginalCpus
         SET RequestCpus            TARGET.TotalCpus ?: JobCpus
     endif
 
-    EVALMACRO test_xcount $(MY.xcount:0) > 1
-    if $(test_xcount)
-        cpus = $(MY.xcount)
-    else
-        EVALMACRO test_orig_RequestCpus $(MY.orig_RequestCpus:0) > 1
-        if $(test_orig_RequestCpus)
-            cpus = $(MY.orig_RequestCpus)
-         else
-            cpus = $(default_xcount:1)
-         endif
-    endif
 
-    EVALSET OriginalCpus           $(cpus)
-    EVALSET remote_SMPGranularity  $(cpus)
-    EVALSET remote_NodeNumber      $(cpus)
-
-    DEFAULT JobIsRunning           (JobStatus =!= 1) && (JobStatus =!= 5)
-    DEFAULT JobCpus                OriginalCpus
-    DEFAULT RequestCpus            OriginalCpus
 @jrt
 
 
@@ -191,49 +191,42 @@ JOB_ROUTER_TRANSFORM_Gpus @=jrt
     # Request GPUs for whole node jobs (HTCONDOR-103)
     # If a whole node job requests GPUs and is matched to a machine with GPUs then set the job's RequestGPUs to all the
     # GPUs on that machine
+    REQUIREMENTS RequestGpus isnt undefined
     if $(test_want_whole_node)
-        SET JOB_GLIDEIN_GPUs       "$$(MY.TotalGPUs ?: JobGPUs)"
+        SET JOB_GLIDEIN_GPUs       "$$([MY.TotalGPUs ?: JobGPUs])"
         # MATCH_EXP_JOB_GLIDEIN_GPUs is based on the value of JOB_GLIDEIN_GPUs once the routed job is matched to an
         # HTCondor slot
         SET GlideinGPUsIsGood      int(MATCH_EXP_JOB_GLIDEIN_GPUs ?: "0") isnt error
+        COPY RequestGPUs           OriginalGPUs
         SET JobGPUs                JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_GPUs) : OriginalGPUs
         SET RequestGPUs            (TARGET.TotalGPUs > 0) ? TotalGPUs: JobGPUs
     endif
-
-    EVALSET OriginalGPUs           $(MY.orig_RequestGPUs)
-    DEFAULT RequestGPUs            OriginalGPUs
 @jrt
 
 
 JOB_ROUTER_TRANSFORM_Memory @=jrt
-    # Outside of the HTCondor WholeNodeJobs case, set RequestCpus to one of the following, in order:
-    # 1. 'maxMemory' from the source job if it's positive
-    # 2. RequestMemory from the source job
-    # 3. default_MaxMemory from the job route
-    # 4. 2000
+    # Outside of the HTCondor WholeNodeJobs case, set RequestMemory to one of the following, in order:
+    # 1. 'maxMemory' from the source job if it's defined
+    # 2. default_MaxMemory from the job route
+    # 3. 2000
+    # Note that if the route does the condor thing and sets RequestMemory, this transform will stomp on that
+
+    EVALSET RequestMemory maxMemory ?: ($(default_maxMemory:2000))
+
+    # set JobMemory so we have a common attribute between regular and WholeNode jobs
+    # that can be queried even when the job is not running
+    SET JobMemory RequestMemory
+
     if $(test_want_whole_node)
-        SET JOB_GLIDEIN_Memory     "$$(MY.TotalMemory ?: 0)"
+        SET JOB_GLIDEIN_Memory     "$$(TotalMemory:0)"
+        # Save RequestMemory to OriginalMemory for later use, 
+        # and if OriginalMemory is needed, remote_OriginalMemory is needed also because blahp
+        COPY RequestMemory OriginalMemory
+        COPY RequestMemory remote_OriginalMemory
         SET JobMemory              JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Memory)*95/100 : OriginalMemory
         SET RequestMemory          TARGET.TotalMemory ? TotalMemory*95/100 : JobMemory
     endif
 
-    EVALMACRO test_maxmemory $(MY.maxMemory:0) > 1
-    if $(test_maxmemory)
-        mem = $(MY.maxMemory)
-    else
-        EVALMACRO test_orig_RequestMemory $(MY.orig_RequestMemory:0) > 1
-        if $(test_orig_RequestMemory)
-            mem = $(MY.orig_RequestMemory)
-         else
-            mem = $(default_maxMemory:2000)
-         endif
-    endif
-
-    EVALSET OriginalMemory         $(mem)
-    EVALSET remote_OriginalMemory  $(mem)
-
-    DEFAULT JobMemory              OriginalMemory
-    DEFAULT RequestMemory          OriginalMemory
 @jrt
 
 


### PR DESCRIPTION
   Fix bugs and make more consistent with old syntax default route, in particular
     RequestCpus from incoming job is ignored and overwritten unless > 1
     RequestMemory from incoming job is ignored and overwritten
   We do this because CE Admins are reporting that incoming values for RequestCpus
   and RequestMemory are often the minimal defaults set by condor_submit rather than