### PR TITLE
Re-enable search bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ markdown_extensions:
   - pymdownx.superfences
 
 plugins:
+  - search
   - redirects:
       redirect_maps:
         'v5/verification.md': 'v5/operation.md'


### PR DESCRIPTION
When enabling other plugins, the search bar has to be explicitly enabled. Same as https://github.com/opensciencegrid/docs/pull/869