### PR TITLE
Ensure default MaxJobs/MaxIdleJobs are the same for all JR syntaxes

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -20,6 +20,10 @@ LOCAL_CONFIG_FILE = /usr/share/condor-ce/condor_ce_router_defaults|
 CONDORCE_MAX_JOBS = 10000
 GRIDMANAGER_MAX_SUBMITTED_JOBS_PER_RESOURCE = $(CONDORCE_MAX_JOBS)
 
+# Set the same MaxJobs/MaxIdleJobs when using the job router transform syntax
+JOB_ROUTER_DEFAULT_MAX_IDLE_JOBS_PER_ROUTE = 2000
+JOB_ROUTER_DEFAULT_MAX_JOBS_PER_ROUTE = $(CONDORCE_MAX_JOBS)
+
 # Only route jobs for either the vanilla or standard universe.
 JOB_ROUTER_SOURCE_JOB_CONSTRAINT = target.JobUniverse =?= 5 || target.JobUniverse =?= 1
 
@@ -117,9 +121,6 @@ JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = Base Cleanup OrigRequests
 JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = Cpus Gpus Memory Queue BatchRuntime CERequirements OnExitHold
 
 JOB_ROUTER_TRANSFORM_Base @=jrt
-    # Job Router special values
-    MaxIdleJobs                    = 2000
-    MaxJobs                        = $(CONDORCE_MAX_JOBS)
     # Always set the following routed job attributes
     SET RoutedJob                  True
     SET Requirements               True


### PR DESCRIPTION
(HTCONDOR-718)

This change makes the default MaxJobs and MaxIdleJobs the same across transform and JRD/JRE syntaxes