### PR TITLE
Get the right env var for the token path

### DIFF
--- a/tests/containers/entrypoint/renew-demo-token.py
+++ b/tests/containers/entrypoint/renew-demo-token.py
@@ -34,7 +34,7 @@ req = request.Request("https://demo.scitokens.org/issue",
 resp = request.urlopen(req).read()
 
 # Convert the "bytes" response to text
-token_path = os.environ.get('BEARER_TOKEN', '') or \
+token_path = os.environ.get('BEARER_TOKEN_FILE', '') or \
     f"/tmp/bt_u{os.geteuid()}"
 
 with open(token_path, 'w') as f:


### PR DESCRIPTION
BEARER_TOKEN is the contents of the token; BEARER_TOKEN_FILE is the path to the token file