### PR TITLE
Fix reference to default_CERequirements job attr (HTCONDOR-964)

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -272,7 +272,7 @@ JOB_ROUTER_TRANSFORM_BatchRuntime @=jrt
 
 JOB_ROUTER_TRANSFORM_CERequirements @=jrt
     SET CondorCE 1
-    EVALSET CERequirements join(",", split("$F(default_CERequirements),CondorCE"))
+    EVALSET CERequirements join(",", split("$F(MY.default_CERequirements),CondorCE"))
 @jrt
 
 


### PR DESCRIPTION
Without this, users always get:

CERequirements = "default_CERequirements,CondorCE"