### PR TITLE
HTCONDOR-1206: Fix failed builds

### DIFF
--- a/.github/workflows/build_and_test_rpms.yml
+++ b/.github/workflows/build_and_test_rpms.yml
@@ -12,7 +12,6 @@ jobs:
           - rockylinux:8
         target_env:
           - uw_build
-          - osg-3.5-upcoming
           - osg-3.6
           - osg-3.6-upcoming
     steps:

--- a/rpm/htcondor-ce.spec
+++ b/rpm/htcondor-ce.spec
@@ -356,6 +356,9 @@ fi
 %files apel
 %{_datadir}/condor-ce/apel/README.md
 %{_datadir}/condor-ce/condor_batch_blah.py
+%if 0%{?rhel} < 8
+%{_datadir}/condor-ce/__pycache__/condor_batch_blah.*.pyc
+%endif
 %{_datadir}/condor-ce/condor_ce_apel.sh
 %{_datadir}/condor-ce/config.d/50-ce-apel-defaults.conf
 %{_sysconfdir}/condor/config.d/50-condor-apel.conf


### PR DESCRIPTION
I fixed up the build failures. These are purely mechanical changes.
- osg-3.5-upcoming is no longer supported, dropped from build
- package additional .pyc files for apel script (on EL7)