### PR TITLE
HTCONDOR-1522 Remove some hard-coded directory permission checks

### DIFF
--- a/src/condor_ce_startup
+++ b/src/condor_ce_startup
@@ -12,8 +12,9 @@ fail() {
 [ -f /usr/share/condor-ce/condor_ce_env_bootstrap ] && . /usr/share/condor-ce/condor_ce_env_bootstrap
 
 # Verify that required dirs are owned by condor:condor (SOFTWARE-2806)
-required_dirs="/var/log/condor-ce /var/log/condor-ce/user
-/var/lock/condor-ce /var/lock/condor-ce/user"
+log_dir=$(condor_ce_config_val LOG)
+lock_dir=$(condor_ce_config_val LOCK)
+required_dirs="${log_dir} ${log_dir}/user ${lock_dir} ${lock_dir}/user"
 bad_dirs=$(stat --format "%n %U" $required_dirs | awk '$2 != "condor" {print $0}')
 [ -z "$bad_dirs" ] || fail 1 "The following directories are not owned by the condor user:\n$bad_dirs"
 

--- a/src/condor_ce_startup
+++ b/src/condor_ce_startup
@@ -12,8 +12,8 @@ fail() {
 [ -f /usr/share/condor-ce/condor_ce_env_bootstrap ] && . /usr/share/condor-ce/condor_ce_env_bootstrap
 
 # Verify that required dirs are owned by condor:condor (SOFTWARE-2806)
-required_dirs="/var/run/condor-ce /var/log/condor-ce /var/log/condor-ce/user /var/lib/condor-ce /var/lib/condor-ce/spool
-/var/lib/condor-ce/execute /var/lock/condor-ce /var/lock/condor-ce/user"
+required_dirs="/var/log/condor-ce /var/log/condor-ce/user
+/var/lock/condor-ce /var/lock/condor-ce/user"
 bad_dirs=$(stat --format "%n %U" $required_dirs | awk '$2 != "condor" {print $0}')
 [ -z "$bad_dirs" ] || fail 1 "The following directories are not owned by the condor user:\n$bad_dirs"
 


### PR DESCRIPTION
These existance/permission checks assume the admin hasn't altered the default locations, and least SPOOL is likely to ben relocated. The condor_master will create these directories if necessary, in the locations given in the configuration files.
Leaving the checks for LOG and LOCK, since the master needs to write to its log file before creating these directories and the user subdirectories are not created by the master.