### PR TITLE
HTCONDOR-1651 Overhaul SSL certificate configuration

### DIFF
--- a/config/01-ce-auth.conf
+++ b/config/01-ce-auth.conf
@@ -7,22 +7,6 @@
 #
 ###############################################################################
 
-# Uncomment the following lines if your SciTokens or SSL clients use
-# grid certificates or your HTCondor-CE's host certificate is located
-# in the standard grid location
-#
-# https://htcondor-ce.readthedocs.io/en/latest/installation/htcondor-ce#configuring-certificates
-
-# AUTH_SSL_SERVER_CERTFILE = /etc/grid-security/hostcert.pem
-# AUTH_SSL_SERVER_KEYFILE = /etc/grid-security/hostkey.pem
-# AUTH_SSL_SERVER_CADIR = /etc/grid-security/certificates
-# AUTH_SSL_SERVER_CAFILE =
-# AUTH_SSL_CLIENT_CERTFILE = /etc/grid-security/hostcert.pem
-# AUTH_SSL_CLIENT_KEYFILE = /etc/grid-security/hostkey.pem
-# AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
-# AUTH_SSL_CLIENT_CAFILE =
-
-
 # By default, regular expressions in the second field of HTCondor-CE
 # mapfiles must be enclosed with '/'. For exmaple:
 #

--- a/config/01-common-auth-defaults.conf
+++ b/config/01-common-auth-defaults.conf
@@ -21,8 +21,16 @@ SEC_PASSWORD_DIRECTORY = /etc/condor-ce/passwords.d
 # GSI settings
 CERTIFICATE_MAPFILE=/etc/condor-ce/condor_mapfile
 
-# SSL settings, appropriate for non-grid hosts
-AUTH_SSL_SERVER_CAFILE = /etc/pki/tls/certs/ca-bundle.crt
+# Alter SSL settings to work with both standard and grid file locations
+AUTH_SSL_SERVER_CERTFILE = /etc/pki/tls/certs/localhost.crt,/etc/grid-security/hostcert.pem
+AUTH_SSL_SERVER_KEYFILE = /etc/pki/tls/private/localhost.key,/etc/grid-security/hostkey.pem
+AUTH_SSL_SERVER_CADIR = /etc/grid-security/certificates
+AUTH_SSL_CLIENT_CERTFILE = /etc/pki/tls/certs/localhost.crt,/etc/grid-security/hostcert.pem
+AUTH_SSL_CLIENT_KEYFILE = /etc/pki/tls/private/localhost.key,/etc/grid-security/hostkey.pem
+AUTH_SSL_CLIENT_CADIR = /etc/grid-security/certificates
+
+# Don't let the collector auto-generate a CA and host cert
+COLLECTOR_BOOTSTRAP_SSL_CERTIFICATE = false
 
 # By default, condor_q attempts to authN a user to only show them their jobs
 # Since read access is optional, this can cause unexpected authN failures


### PR DESCRIPTION
Now, the base configuration works out-of-the-box with either the standard or grid certificate file locations.
Also, disable and ignore the collector's autogenerated CA and host cert.