### PR TITLE
HTCONDOR-1968: Warn about old job router configuration syntax depreca…

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -112,7 +112,7 @@ MERGE_JOB_ROUTER_DEFAULT_ADS=True
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS_GENERATED)
 

--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -106,6 +106,14 @@ SCHEDD_ATTRS = $(SCHEDD_ATTRS) HTCondorCEVersion grid_resource
 #   JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS) [set_foo = 1;]
 #
 MERGE_JOB_ROUTER_DEFAULT_ADS=True
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS_GENERATED)
 
 # Use JOB_ROUTER_DEFAULTS + JOB_ROUTER_ENTRIES by default instead of

--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -109,7 +109,7 @@ MERGE_JOB_ROUTER_DEFAULT_ADS=True
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/01-ce-router.conf
+++ b/config/01-ce-router.conf
@@ -46,7 +46,7 @@ MERGE_JOB_ROUTER_DEFAULT_ADS=True
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS_GENERATED)
 

--- a/config/01-ce-router.conf
+++ b/config/01-ce-router.conf
@@ -40,6 +40,14 @@ ROUTED_JOB_MAX_TIME = 4320
 #   JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS) [set_foo = 1;]
 #
 MERGE_JOB_ROUTER_DEFAULT_ADS=True
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS_GENERATED)
 
 

--- a/config/01-ce-router.conf
+++ b/config/01-ce-router.conf
@@ -43,7 +43,7 @@ MERGE_JOB_ROUTER_DEFAULT_ADS=True
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-bosco-defaults.conf
+++ b/config/02-ce-bosco-defaults.conf
@@ -10,6 +10,14 @@
 
 # Basic route for submitting to BOSCO
 # Use osg-configure to set BOSCO_RMS and BOSCO_ENDPOINT
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES = \
    [ \
      GridResource = "batch $(BOSCO_RMS) $(BOSCO_ENDPOINT)"; \

--- a/config/02-ce-bosco-defaults.conf
+++ b/config/02-ce-bosco-defaults.conf
@@ -16,7 +16,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES = \
    [ \

--- a/config/02-ce-bosco-defaults.conf
+++ b/config/02-ce-bosco-defaults.conf
@@ -13,7 +13,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-bosco.conf
+++ b/config/02-ce-bosco.conf
@@ -8,6 +8,14 @@
 
 # Basic route for submitting to BOSCO
 # Use osg-configure to set BOSCO_RMS and BOSCO_ENDPOINT
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES = \
    [ \
      GridResource = "batch $(BOSCO_RMS) $(BOSCO_ENDPOINT)"; \

--- a/config/02-ce-bosco.conf
+++ b/config/02-ce-bosco.conf
@@ -11,7 +11,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-bosco.conf
+++ b/config/02-ce-bosco.conf
@@ -14,7 +14,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES = \
    [ \

--- a/config/02-ce-condor-defaults.conf
+++ b/config/02-ce-condor-defaults.conf
@@ -13,7 +13,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-condor-defaults.conf
+++ b/config/02-ce-condor-defaults.conf
@@ -10,7 +10,14 @@
 ###############################################################################
 
 # Submit the job to the site Condor
-
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   TargetUniverse = 5;

--- a/config/02-ce-condor-defaults.conf
+++ b/config/02-ce-condor-defaults.conf
@@ -16,7 +16,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-condor.conf
+++ b/config/02-ce-condor.conf
@@ -11,7 +11,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-condor.conf
+++ b/config/02-ce-condor.conf
@@ -14,7 +14,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-condor.conf
+++ b/config/02-ce-condor.conf
@@ -8,7 +8,14 @@
 ###############################################################################
 
 # Submit the job to the site Condor
-
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   TargetUniverse = 5;

--- a/config/02-ce-lsf-defaults.conf
+++ b/config/02-ce-lsf-defaults.conf
@@ -9,6 +9,14 @@
 ###############################################################################
 
 # Basic route for submitting to LSF
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch lsf";

--- a/config/02-ce-lsf-defaults.conf
+++ b/config/02-ce-lsf-defaults.conf
@@ -15,7 +15,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-lsf-defaults.conf
+++ b/config/02-ce-lsf-defaults.conf
@@ -12,7 +12,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-lsf.conf
+++ b/config/02-ce-lsf.conf
@@ -13,7 +13,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-lsf.conf
+++ b/config/02-ce-lsf.conf
@@ -10,7 +10,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-lsf.conf
+++ b/config/02-ce-lsf.conf
@@ -7,6 +7,14 @@
 ###############################################################################
 
 # Basic route for submitting to LSF
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch lsf";

--- a/config/02-ce-pbs-defaults.conf
+++ b/config/02-ce-pbs-defaults.conf
@@ -9,6 +9,14 @@
 ###############################################################################
 
 # Basic route for submitting to PBS
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch pbs";

--- a/config/02-ce-pbs-defaults.conf
+++ b/config/02-ce-pbs-defaults.conf
@@ -15,7 +15,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-pbs-defaults.conf
+++ b/config/02-ce-pbs-defaults.conf
@@ -12,7 +12,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-pbs.conf
+++ b/config/02-ce-pbs.conf
@@ -7,6 +7,14 @@
 ###############################################################################
 
 # Basic route for submitting to PBS
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch pbs";

--- a/config/02-ce-pbs.conf
+++ b/config/02-ce-pbs.conf
@@ -13,7 +13,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-pbs.conf
+++ b/config/02-ce-pbs.conf
@@ -10,7 +10,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-sge-defaults.conf
+++ b/config/02-ce-sge-defaults.conf
@@ -9,6 +9,14 @@
 ###############################################################################
 
 # Basic route for submitting to SGE
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch sge";

--- a/config/02-ce-sge-defaults.conf
+++ b/config/02-ce-sge-defaults.conf
@@ -15,7 +15,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-sge-defaults.conf
+++ b/config/02-ce-sge-defaults.conf
@@ -12,7 +12,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-sge.conf
+++ b/config/02-ce-sge.conf
@@ -7,6 +7,14 @@
 ###############################################################################
 
 # Basic route for submitting to SGE
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch sge";

--- a/config/02-ce-sge.conf
+++ b/config/02-ce-sge.conf
@@ -13,7 +13,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-sge.conf
+++ b/config/02-ce-sge.conf
@@ -10,7 +10,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-slurm-defaults.conf
+++ b/config/02-ce-slurm-defaults.conf
@@ -15,7 +15,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-slurm-defaults.conf
+++ b/config/02-ce-slurm-defaults.conf
@@ -9,6 +9,14 @@
 ###############################################################################
 
 # Basic route for submitting to Slurm
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch slurm";

--- a/config/02-ce-slurm-defaults.conf
+++ b/config/02-ce-slurm-defaults.conf
@@ -12,7 +12,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-slurm.conf
+++ b/config/02-ce-slurm.conf
@@ -13,7 +13,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [

--- a/config/02-ce-slurm.conf
+++ b/config/02-ce-slurm.conf
@@ -10,7 +10,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/config/02-ce-slurm.conf
+++ b/config/02-ce-slurm.conf
@@ -7,6 +7,14 @@
 ###############################################################################
 
 # Basic route for submitting to Slurm
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES @=jre
 [
   GridResource = "batch slurm";

--- a/contrib/puppet/osg_ce_condor/files/config.d/02-ce-pbs.conf
+++ b/contrib/puppet/osg_ce_condor/files/config.d/02-ce-pbs.conf
@@ -11,7 +11,7 @@
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
 #          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
-#          HTCondor. New configuration syntax for the job router is defined using
+#          the HTCondor Software Suite. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
 #   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.

--- a/contrib/puppet/osg_ce_condor/files/config.d/02-ce-pbs.conf
+++ b/contrib/puppet/osg_ce_condor/files/config.d/02-ce-pbs.conf
@@ -8,6 +8,14 @@
 ###############################################################################
 
 # Basic route for submitting to PBS
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Warning: JOB_ROUTER_DEFAULTS, JOB_ROUTER_ENTRIES, JOB_ROUTER_ENTRIES_CMD, and
+#          JOB_ROUTER_ENTRIES_FILE are deprecated and will be removed for V24 of
+#          HTCondor. New configuration syntax for the job router is defined using
+#          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
+# https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
+#   Note: The removal will occur earlier in the development series HTCondor V23.
+#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES = \
    [ \
      GridResource = "batch pbs"; \

--- a/contrib/puppet/osg_ce_condor/files/config.d/02-ce-pbs.conf
+++ b/contrib/puppet/osg_ce_condor/files/config.d/02-ce-pbs.conf
@@ -14,7 +14,7 @@
 #          HTCondor. New configuration syntax for the job router is defined using
 #          JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For new syntax example visit:
 # https://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration
-#   Note: The removal will occur earlier in the development series HTCondor V23.
+#   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 JOB_ROUTER_ENTRIES = \
    [ \

--- a/src/verify_ce_config.py
+++ b/src/verify_ce_config.py
@@ -83,10 +83,10 @@ def main():
             if knob in htcondor.param:
                 used_deprecated_knobs.append(knob)
         if len(used_deprecated_knobs) > 0:
-            warn("%s are deprecated and will be removed for V24 of HTCondor. New configuration"
-                 % ", ".join(used_deprecated_knobs)
-                 + " syntax for the job router is defined using JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>."
-                 + " Note: The removal will occur during the lifetime of the HTCondor V23 feature series.\n")
+            warn(f"{', '.join(used_deprecated_knobs)} are deprecated and will be removed for V24 of HTCondor. New configuration"
+                 + " syntax for the job router is defined using JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For example"
+                 + " use of new syntax visit:\nhttps://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration\n\n"
+                 + "   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.\n")
 
         for attr in ['JOB_ROUTER_DEFAULTS', 'JOB_ROUTER_ENTRIES']:
             try:

--- a/src/verify_ce_config.py
+++ b/src/verify_ce_config.py
@@ -78,6 +78,16 @@ def main():
 
     # If no JOB_ROUTER_ROUTE_<name> rules exist, verify JOB_ROUTER_DEFAULTS and JOB_ROUTER_ENTRIES
     else:
+        used_deprecated_knobs = []
+        for knob in ['JOB_ROUTER_DEFAULTS', 'JOB_ROUTER_ENTRIES', 'JOB_ROUTER_ENTRIES_CMD','JOB_ROUTER_ENTRIES_FILE']:
+            if knob in htcondor.param:
+                used_deprecated_knobs.append(knob)
+        if len(used_deprecated_knobs) > 0:
+            warn("%s are deprecated and will be removed for V24 of HTCondor. New configuration"
+                 % ", ".join(used_deprecated_knobs)
+                 + " syntax for the job router is defined using JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>."
+                 + " Note: The removal will occur during the lifetime of the HTCondor V23 feature series.\n")
+
         for attr in ['JOB_ROUTER_DEFAULTS', 'JOB_ROUTER_ENTRIES']:
             try:
                 config_val = htcondor.param[attr]

--- a/src/verify_ce_config.py
+++ b/src/verify_ce_config.py
@@ -83,7 +83,7 @@ def main():
             if knob in htcondor.param:
                 used_deprecated_knobs.append(knob)
         if len(used_deprecated_knobs) > 0:
-            warn(f"{', '.join(used_deprecated_knobs)} are deprecated and will be removed for V24 of HTCondor. New configuration"
+            warn(f"{', '.join(used_deprecated_knobs)} are deprecated and will be removed for V24 of the HTCondor Software Suite. New configuration"
                  + " syntax for the job router is defined using JOB_ROUTER_ROUTE_NAMES and JOB_ROUTER_ROUTE_<name>. For example"
                  + " use of new syntax visit:\nhttps://htcondor.readthedocs.io/en/latest/grid-computing/job-router.html#an-example-configuration\n\n"
                  + "   Note: The removal will occur during the lifetime of the HTCondor V23 feature series.\n")


### PR DESCRIPTION
…tion

-Added warning message to all provided configuration files
 at the use of one of the deprecated macros
-In verify_ce_config.py if using the old configuration display
 warning message