### PR TITLE
HTCONDOR-2193 gpu-reqs

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -131,7 +131,12 @@ JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = Cpus Gpus Memory Queue BatchRuntime CERe
 JOB_ROUTER_TRANSFORM_Base @=jrt
     # Always set the following routed job attributes
     SET RoutedJob                  True
-    SET Requirements               True
+    # Older Condor-C jobs don't add this requirement for GPU jobs and
+    # startds don't add a check if GPU detection is not enabled.
+    EVALMACRO test_requirements_true unparse(Requirements)=="true"
+    if $(test_requirements_true)
+        SET Requirements           (RequestGpus?:0) >= (TARGET.Gpus?:0)
+    endif
 
 @jrt
 

--- a/src/condor_ce_router_defaults
+++ b/src/condor_ce_router_defaults
@@ -60,7 +60,7 @@ JOB_ROUTER_DEFAULTS_GENERATED @=jrd
 
     /* Set new requirements */
     /* set_requirements = LastClientContact - time() < 30*60; */
-    set_requirements = True;
+    set_requirements = (RequestGpus?:0) >= (TARGET.Gpus?:0);
 
     /* Note default memory request of 2GB */
     /* Note yet another nested condition allow pass attributes (maxMemory,xcount,jobtype,queue)


### PR DESCRIPTION
Condor-C jobs won't have this check added automatically and startds that don't have GPU detection won't include a check. If we don't add a check here, then jobs with RequestGPUs set can end up running on machines with no GPUs when routed to a local HTCondor pool.

We only set Requirements if it's currently the literal value 'true'. We expect newer clients to start setting all of the automatic requirements clauses for Condor-C jobs, and we don't want to ignore those.