### PR TITLE
HTCONDOR-2276 cereqs-default

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -287,7 +287,11 @@ JOB_ROUTER_TRANSFORM_BatchRuntime @=jrt
 
 JOB_ROUTER_TRANSFORM_CERequirements @=jrt
     SET CondorCE 1
-    EVALSET CERequirements join(",", split("$F(MY.default_CERequirements),CondorCE"))
+    if defined MY.default_CERequirements
+        SET CERequirements "$(MY.default_CERequirements),CondorCE"
+    else
+        SET CERequirements "CondorCE"
+    endif
 @jrt
 
 


### PR DESCRIPTION
When default_CERequirements isn't set in the job ad, '$F(MY.default_CERequirements)' expands to 'MY.default_CERequirements' instead of an empty string.