### PR TITLE
superusers are also queue superusers

### DIFF
--- a/config/05-ce-auth-defaults.conf
+++ b/config/05-ce-auth-defaults.conf
@@ -37,7 +37,7 @@ SCHEDD.ALLOW_NEGOTIATOR = condor@daemon.htcondor.org/$(FULL_HOSTNAME)
 ALLOW_DAEMON = $(FRIENDLY_DAEMONS)
 C_GAHP.ALLOW_DAEMON = $(ALLOW_DAEMON)
 ALLOW_ADMINISTRATOR = $(SUPERUSERS)
-QUEUE_SUPER_USERS = condor, root
+QUEUE_SUPER_USERS = $(SUPERUSERS)
 
 # This security setting is likely unnecessary as we don't run a negotiator.
 # However, we'd prefer to see the least number of authorizations possible.


### PR DESCRIPTION
This PR fixes the permissions of the `root` and `condor` users for queue commands.

Currently, `QUEUE_SUPER_USERS = condor, root` lacks a domain so the `UID_DOMAIN = users.htcondor.org` is implied. However, the [default mapping for local `root`/`condor` users](https://github.com/htcondor/htcondor-ce/blob/729edd27f5c1f25f2926a04cb5c6fd2fd1433f45/config/mapfiles.d/50-common-default.conf#L12) uses the domain `daemon.htcondor.org` instead. As such, `root` is not allowed to perform administrative queue commands such as `condor_ce_rm`.