### PR TITLE
HTCONDOR-2371 whole-node-memory

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -242,7 +242,7 @@ JOB_ROUTER_TRANSFORM_Memory @=jrt
         COPY RequestMemory OriginalMemory
         COPY RequestMemory remote_OriginalMemory
         SET JobMemory              JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_Memory)*95/100 : OriginalMemory
-        SET RequestMemory          TARGET.TotalMemory ? TotalMemory*95/100 : JobMemory
+        SET RequestMemory          TARGET.TotalMemory*95/100 ?: JobMemory
     endif
 
 @jrt


### PR DESCRIPTION
The old expression would evaluate to Undefined for grid universe jobs, leading to no memory request being passed to the blahp.