### PR TITLE
HTCONDOR-2501 Fix whole-node gpu routing to work with non-condor systems

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -217,7 +217,7 @@ JOB_ROUTER_TRANSFORM_Gpus @=jrt
         SET GlideinGPUsIsGood      int(MATCH_EXP_JOB_GLIDEIN_GPUs ?: "0") isnt error
         COPY RequestGPUs           OriginalGPUs
         SET JobGPUs                JobIsRunning ? int(MATCH_EXP_JOB_GLIDEIN_GPUs) : OriginalGPUs
-        SET RequestGPUs            (TARGET.TotalGPUs > 0) ? TotalGPUs: JobGPUs
+        SET RequestGPUs            ((TARGET.TotalGPUs ?: 0) > 0) ? TotalGPUs: JobGPUs
     endif
 @jrt
 


### PR DESCRIPTION
The existing expression for RequestGPUs will always evaluate to Undefined outside of HTCondor matchmaking against a slot ad.