### PR TITLE
HTCONDOR-2549 daemon domain

### DIFF
--- a/config/05-ce-auth-defaults.conf
+++ b/config/05-ce-auth-defaults.conf
@@ -16,8 +16,8 @@ DENY_ADMINISTRATOR = anonymous@*, *@unmapped
 DENY_DAEMON = anonymous@*, *@unmapped
 
 # Defaults authorizations
-SUPERUSERS = condor@daemon.htcondor.org/$(FULL_HOSTNAME), root@daemon.htcondor.org/$(FULL_HOSTNAME)
-FRIENDLY_DAEMONS = condor@daemon.htcondor.org/$(FULL_HOSTNAME) condor@child/$(FULL_HOSTNAME)
+SUPERUSERS = condor@$(UID_DOMAIN)/$(FULL_HOSTNAME), root@$(UID_DOMAIN)/$(FULL_HOSTNAME)
+FRIENDLY_DAEMONS = condor@$(UID_DOMAIN)/$(FULL_HOSTNAME) condor@child/$(FULL_HOSTNAME)
 # Setting the UID_DOMAIN appends @users.htcondor.org to GUMS mappings.
 UID_DOMAIN = users.htcondor.org
 USERS = *@users.htcondor.org
@@ -28,14 +28,12 @@ UNMAPPED_USERS = ssl@unmapped
 
 # Authz settings for each daemon.  Preferably, change the templates above
 ALLOW_READ = *
-ALLOW_WRITE = $(FRIENDLY_DAEMONS)
-SCHEDD.ALLOW_WRITE = $(USERS), condor@daemon.htcondor.org/$(FULL_HOSTNAME)
-COLLECTOR.ALLOW_ADVERTISE_MASTER = $(FRIENDLY_DAEMONS)
-COLLECTOR.ALLOW_ADVERTISE_SCHEDD = $(FRIENDLY_DAEMONS)
-COLLECTOR.ALLOW_ADVERTISE_STARTD =  $(UNMAPPED_USERS), $(USERS)
-SCHEDD.ALLOW_NEGOTIATOR = condor@daemon.htcondor.org/$(FULL_HOSTNAME)
+ALLOW_WRITE = $(USERS), condor@$(UID_DOMAIN)/$(FULL_HOSTNAME)
+ALLOW_ADVERTISE_MASTER = $(FRIENDLY_DAEMONS)
+ALLOW_ADVERTISE_SCHEDD = $(FRIENDLY_DAEMONS)
+ALLOW_ADVERTISE_STARTD =  $(UNMAPPED_USERS), $(USERS)
+ALLOW_NEGOTIATOR = condor@$(UID_DOMAIN)/$(FULL_HOSTNAME)
 ALLOW_DAEMON = $(FRIENDLY_DAEMONS)
-C_GAHP.ALLOW_DAEMON = $(ALLOW_DAEMON)
 ALLOW_ADMINISTRATOR = $(SUPERUSERS)
 QUEUE_SUPER_USERS = condor, root
 

--- a/config/mapfiles.d/50-common-default.conf
+++ b/config/mapfiles.d/50-common-default.conf
@@ -9,5 +9,4 @@
 ###############################################################################
 
 CLAIMTOBE /.*/ anonymous@claimtobe
-FS /^(root|condor)$/ \1@daemon.htcondor.org
 FS /(.*)/ \1


### PR DESCRIPTION
Use the local UID_DOMAIN (users.htcondor.org) for the identity of 'condor' clients. Otherwise, in 23.9.x, the schedd won't recognize the job router as a queue superuser.