### PR TITLE
HTCONDOR-2563 batch-queue

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -250,17 +250,16 @@ JOB_ROUTER_TRANSFORM_Memory @=jrt
 
 
 JOB_ROUTER_TRANSFORM_Queue @=jrt
-    # Set the remote batch queue to one of the following, in order:
-    # 1. 'batch_queue' from the source job
-    # 2. 'queue' from the source job
-    # 3. 'default_queue' from the route
-    # 4. Empty string
-    if defined MY.batch_queue
-       EVALSET remote_queue MY.batch_queue
-    elif defined MY.queue
-       EVALSET remote_queue MY.queue
+    # If BatchQueue isn't already set, then set it from one of the
+    # following, in order:
+    # 1. 'queue' from the source job
+    # 2. 'default_queue' from the route
+    # 3. Empty string
+    REQUIREMENTS BatchQueue is undefined
+    if defined MY.queue
+       EVALSET BatchQueue MY.queue
     else
-       EVALSET remote_queue "$(default_queue)"
+       EVALSET BatchQueue "$(default_queue)"
     endif
 @jrt
 


### PR DESCRIPTION
BatchQueue is the first-class way to specify the queue in the batch system. We should use it instead of queue or remote_queue.