### PR TITLE
HTCONDOR-2637 Request old DN formatting for certificate issuer

### DIFF
--- a/src/condor_ce_host_network_check
+++ b/src/condor_ce_host_network_check
@@ -401,7 +401,7 @@ def main():
     # If the host cert is missing or unreadable, emit a warning but keep going.
     hostcert = htcondor.param.get("GSI_DAEMON_CERT", "/etc/grid-security/hostcert.pem")
     if os.access(hostcert, os.R_OK):
-        fd = os.popen("openssl x509 -in %s -noout -subject" % hostcert)
+        fd = os.popen("openssl x509 -in %s -noout -subject -nameopt compat" % hostcert)
         dn = fd.read().strip()
         if fd.close() or not dn:
             print(f"WARNING: OpenSSL unable to parse host certificate {hostcert}; GSI configuration will likely fail.", file=sys.stderr)


### PR DESCRIPTION
The openssl formats DNs differently in EL7, EL8, and EL9. Request the old format explicitly so that we know how to parse it.