### PR TITLE
HTCONDOR-2703 whole-node

### DIFF
--- a/config/01-ce-router-defaults.conf
+++ b/config/01-ce-router-defaults.conf
@@ -127,7 +127,7 @@ JOB_ROUTER_USE_DEPRECATED_ROUTER_ENTRIES = False
 #################################
 
 JOB_ROUTER_PRE_ROUTE_TRANSFORM_NAMES = Base Cleanup OrigRequests
-JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = Cpus Gpus Memory Queue BatchRuntime CERequirements OnExitHold
+JOB_ROUTER_POST_ROUTE_TRANSFORM_NAMES = WholeNode Cpus Gpus Memory Queue BatchRuntime CERequirements OnExitHold
 
 JOB_ROUTER_TRANSFORM_Base @=jrt
     # Always set the following routed job attributes
@@ -159,10 +159,15 @@ JOB_ROUTER_TRANSFORM_OrigRequests @=jrt
     COPY environment               orig_environment
     # the BLAHP uses WholeNodes=true for the same thing that we use WantWholeNode=true
     COPY WantWholeNode             WholeNodes
+@jrt
 
+
+JOB_ROUTER_TRANSFORM_WholeNode @=jrt
     # Support whole node job requests against HTCondor pools if the source job specifies 'WantWholeNode = True'
-    # 'if' can't handle complex expressions yet so we evaluate it here for use in post-transforms
-    EVALMACRO test_want_whole_node $(MY.WantWholeNode:False)
+    # 'if' can't handle complex expressions yet so we evaluate it here for use in later post-transforms
+    # This only works if submitting directly to the local schedd (i.e. not via
+    # the grid universe).
+    EVALMACRO test_want_whole_node $(MY.WantWholeNode:False) && $(TargetUniverse)==5
 @jrt
 
 


### PR DESCRIPTION
Setting expressions for the routed job's resource requests doesn't work properly if the routed job is going through the grid universe.