### PR TITLE
Apel token accounting

### DIFF
--- a/contrib/apelscripts/50-ce-apel-defaults.conf
+++ b/contrib/apelscripts/50-ce-apel-defaults.conf
@@ -34,3 +34,6 @@ APEL_SCALE_DEFAULT = 1.0
 # because they are executed on the site's central publisher
 APEL_SEND_RECORDS = True
 
+# Extract APEL accounting group from first wlcg.groups defined in WLCG JWT token profile
+# (it is not recommended to enable this option, just to mimic all ARC-CE 7 accounting options)
+APEL_USE_WLCG_GROUPS = False

--- a/contrib/apelscripts/50-condor-apel.conf
+++ b/contrib/apelscripts/50-condor-apel.conf
@@ -16,5 +16,5 @@ PER_JOB_HISTORY_DIR = /var/lib/condor/history
 # group. This mapping is applied only in case there was no delegated VOMS
 # proxy (x509UserProxyFirstFQAN) or in case of enabled APEL_USE_WLCG_GROUPS
 # there was no wlcg.groups claim in job submission token (orig_AuthTokenGroups)
-TOOL_CLASSAD_USER_MAP_NAMES = $(JOB_ROUTER_CLASSAD_USER_MAP_NAMES) ApelAGMap
+TOOL_CLASSAD_USER_MAP_NAMES = $(TOOL_CLASSAD_USER_MAP_NAMES) ApelAGMap
 CLASSAD_USER_MAPFILE_ApelAGMap = /etc/condor/apel_acct_group.map

--- a/contrib/apelscripts/50-condor-apel.conf
+++ b/contrib/apelscripts/50-condor-apel.conf
@@ -10,3 +10,11 @@
 
 SYSTEM_JOB_MACHINE_ATTRS = $(SYSTEM_JOB_MACHINE_ATTRS) ApelScaling ApelSpecs
 PER_JOB_HISTORY_DIR = /var/lib/condor/history
+
+# The /etc/condor/apel_acct_group.map provides a mapping of job owner and
+# orig_AuthTokenIssuer,orig_AuthTokenSubject attributes to APEL accounting
+# group. This mapping is applied only in case there was no delegated VOMS
+# proxy (x509UserProxyFirstFQAN) or in case of enabled APEL_USE_WLCG_GROUPS
+# there was no wlcg.groups claim in job submission token (orig_AuthTokenGroups)
+TOOL_CLASSAD_USER_MAP_NAMES = $(JOB_ROUTER_CLASSAD_USER_MAP_NAMES) ApelAGMap
+CLASSAD_USER_MAPFILE_ApelAGMap = /etc/condor/apel_acct_group.map

--- a/contrib/apelscripts/README.md
+++ b/contrib/apelscripts/README.md
@@ -42,7 +42,26 @@ To create and publish APEL records, use the following instructions
    STARTD_ATTRS = $(STARTD_ATTRS) ApelScaling
    ```
 
-4. Start and enable the `condor-ce-apel.timer` on each HTCondor-CE
+4. Optionally define mapping for APEL accounting groups for jobs without VOMS proxy
+  ```
+  # in the /etc/condor/apel_acct_group.map map Owner or token issuer & subject, e.g.
+  # map local job owner "dteam" to APEL accounting group /dteam
+  * dteam /dteam
+  # map all local owners starting with "ops" to the APEL accounting group /ops
+  * /^ops.*$/ /ops
+  # map ATLAS token issuer and subject to the APEL accounting group
+  * /^https\:\/\/atlas\-auth\.cern\.ch\/,7dee38a3\-6ab8\-4fe2\-9e4c\-58039c21d817$/ /atlas/Role=production/Capability=NULL
+  * /^https\:\/\/atlas\-auth\.cern\.ch\/,5c5d2a4d\-9177\-3efa\-912f\-1b4e5c9fb660$/ /atlas/Role=lcgadmin/Capability=NULL
+  * /^https\:\/\/atlas\-auth\.cern\.ch\/,750e9609\-485a\-4ed4\-bf16\-d5cc46c71024$/ /atlas/Role=pilot/Capability=NULL
+  * /^https\:\/\/atlas\-auth\.cern\.ch\/,.*$/ /atlas/Role=NULL/Capability=NULL
+  # map DUNE token issuer and subject to the APEL accounting group
+  * /^https\:\/\/cilogon\.org\/dune,dunepilot\@fnal\.gov$/ /dune/Role=pilot/Capability=NULL
+  * /^https\:\/\/cilogon\.org\/dune,.*$/ /dune/Role=NULL/Capability=NULL
+  # no way to map individual Fermilab experiments hidden behind one token identity
+  #* /^https\:\/\/cilogon\.org\/fermilab,fermilabpilot\@fnal\.gov$/ NoVA? Minerva? Mu2e? ...
+  ```
+
+5. Start and enable the `condor-ce-apel.timer` on each HTCondor-CE
 
 The default behaviour when a StartD does not properly report performance information
 changed in HTCondor-CE v 5.1.6 to assume average performance in this case.


### PR DESCRIPTION
Basic APEL accounting for job submitted with tokens
Accounting for jobs without delegated VOMS proxy
Provide similar accounting options implemented in ARC-CE 7
(https://bugzilla.nordugrid.org/show_bug.cgi?id=4236).

* no changes for jobs with delegated VOMS proxy (x509UserProxyFirstFQAN)
* optionally use first wlcg.groups with APEL_USE_WLCG_GROUPS enabled
* mapfile for remaining job using Owner or AuthTokenIssuer,AuthTokenSubject

Functionality is limited to HTCondor-CE with local HTCondor.